### PR TITLE
Fix: Dashboard page interactive render mode

### DIFF
--- a/src/EQFR.UI/Components/Pages/Dashboard.razor
+++ b/src/EQFR.UI/Components/Pages/Dashboard.razor
@@ -1,4 +1,5 @@
 @page "/dashboard"
+@rendermode InteractiveServer
 @using EQFR.UI.ViewModels
 @using EQFR.UI.Components
 @inject DashboardViewModel Vm


### PR DESCRIPTION
Menambahkan `@rendermode InteractiveServer` pada halaman `/dashboard` agar tombol Start/Pause/Reset (onclick) benar-benar aktif.