### PR TITLE
Add layout builder and improve factory canvas controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,73 @@
 # EQFR (EQ Factory Realtime) - MVP Realtime Factory
 
-Repo ini adalah MVP simulasi factory realtime berbasis in-memory dan config JSON.
+Repo ini adalah MVP realtime factory untuk demo/testing dengan backend mock in-memory dan UI dashboard realtime.
 
 ## Struktur Solution
 
 - `EQFR.Common` (class library): shared types, enums, contracts.
 - `EQFR.EIFData` (class library): model/config data (layout, routes, process, transport, simulation).
 - `EQFR.IO` (class library): loader config JSON dari folder `config/`.
-- `EQFR.Biz` (class library): runtime state, routing, dispatching, machine + transport engines, snapshot builder.
+- `EQFR.Biz` (class library): kontrak snapshot dan logika domain yang dipakai UI.
 - `EQFR.UI` (host app): Blazor (Interactive Server) untuk menampilkan factory dashboard realtime.
+- `backend-eqfr` (Node/Express): mock backend tanpa database yang generate snapshot factory otomatis dari folder `config/`.
 
 ## Prinsip MVP
 
 - Tidak menggunakan database.
-- Semua runtime state wajib in-memory.
-- Semua config harus berasal dari file JSON di folder `config/`.
+- Semua runtime state in-memory.
+- Semua config berasal dari file JSON di folder `config/`.
+- Backend mock adalah source data untuk UI.
 
 ## Menjalankan Aplikasi
 
 Prasyarat:
-- .NET SDK (repo ini menggunakan target `net10.0`, sehingga idealnya pakai SDK yang sesuai).
+- .NET SDK (`net10.0`)
+- Node.js
 
-Perintah:
+1. Jalankan backend mock:
 
 ```powershell
-dotnet run --project .\src\EQFR.UI
+cd .\backend-eqfr
+npm.cmd start
 ```
 
-Lalu buka:
-- `https://localhost:<port>/dashboard`
+Default backend listen di `http://localhost:3001`.
 
-Catatan:
-- Service simulasi mencari folder `config/` mulai dari `AppContext.BaseDirectory` lalu naik beberapa parent folder.
-- Status awal simulasi adalah `Stopped`. Tekan `Start` untuk mulai tick engine.
+2. Jalankan UI:
 
-## Verifikasi Flow End-to-End (MVP)
+```powershell
+cd ..\src\EQFR.UI
+dotnet run
+```
 
-Dengan config default, flow yang diharapkan:
-- `LOT_001` tersedia di `WH_IN:OUT`
-- Machine `ROLL_PRESS_1` akan request input
-- Dispatcher membuat task: deliver input `WH_IN:OUT -> ROLL_PRESS_1:IN`
-- Machine memproses step `Load -> Press -> Unload`
-- Output ready, lalu dispatcher membuat task: move output `ROLL_PRESS_1:OUT -> WH_OUT:IN`
+3. Buka dashboard:
+- `http://localhost:5042/dashboard`
+- jika port default UI sedang dipakai, aplikasi otomatis pindah ke port berikutnya (`5043`, `5044`, dst.)
 
-Yang harus terlihat di Dashboard:
-- Canvas/layout menampilkan lokasi, edge, dan posisi transport bergerak per tick.
-- Panel `Machine` menampilkan status, lot id, step, flags.
-- Panel `Transport` menampilkan node saat ini, task id, dan lot yang dibawa.
-- `Event Log` menampilkan rangkaian event (dispatch, pickup/dropoff, machine step).
-- Tombol:
-  - `Start`: menjalankan simulasi.
-  - `Pause`: menghentikan tick (state tidak berubah, tapi UI tetap update snapshot).
-  - `Reset`: rebuild runtime state dari config (kembali ke kondisi awal).
+## Flow Saat Ini
 
-## Konfigurasi
+- Backend membaca `config/` saat startup.
+- Backend generate snapshot factory secara otomatis tanpa database.
+- UI polling `http://localhost:3001/api/snapshot` lalu menampilkan hasilnya di dashboard realtime.
+- Dashboard berjalan otomatis tanpa tombol start/pause/reset.
 
-Folder: `config/`
+## Endpoint Backend Mock
 
-File utama:
-- `factory-layout.json`: lokasi, posisi, dan port.
-- `factory-routes.json`: edge/route yang boleh dilewati transport.
-- `factory-transport.json`: daftar transport dan start node.
-- `factory-process.json`: machine process steps (MVP: Roll Press).
-- `factory-simulation.json`: tick interval, max event, initial lots.
+- `GET /health`
+- `GET /api/config`
+- `GET /api/snapshot`
+- `GET /api/controls`
+- `POST /api/controls/start`
+- `POST /api/controls/pause`
+- `POST /api/controls/stop`
+- `POST /api/controls/reset`
+- `POST /api/controls/consume-reset`
 
 ## Troubleshooting Cepat
 
-- Transport tidak bergerak:
-  - Pastikan `factory-routes.json` membentuk graph yang terhubung dari start node transport ke pickup/dropoff node.
-- UI tidak update:
-  - Pastikan `dotnet run --project .\src\EQFR.UI` sukses tanpa error dan akses `/dashboard`.
-
+- Dashboard kosong atau `Menunggu snapshot realtime...`
+  - pastikan backend `npm.cmd start` berjalan di `http://localhost:3001`
+- `address already in use` saat menjalankan UI
+  - instance kedua UI akan fallback ke port lokal berikutnya; lihat URL di console
+- Backend gagal start
+  - pastikan folder `config/` ada di root repo dan file JSON valid

--- a/backend-eqfr/README.md
+++ b/backend-eqfr/README.md
@@ -1,14 +1,18 @@
 # Backend EQFR (Express.js)
 
-Backend ini menyediakan HTTP API sederhana agar bisa diakses oleh EQFR (atau client lain) untuk:
+Backend ini menyediakan mock API tanpa database untuk demo/testing EQFR.
+
+## Fungsi
+
 - membaca config dari folder `/config`
-- membaca/mengirim snapshot runtime (in-memory)
-- mengirim command kontrol (start/pause/reset)
+- generate snapshot runtime factory secara otomatis di memory
+- expose snapshot dan control endpoint untuk diakses UI
 
 ## Prinsip MVP
 
-- Tanpa database (semua state backend in-memory).
-- Config hanya dibaca dari folder `/config` di root repo.
+- Tanpa database
+- Semua state backend in-memory
+- Config dibaca dari folder `/config` di root repo
 
 ## Menjalankan
 
@@ -22,28 +26,26 @@ npm.cmd start
 
 Default listen di `http://localhost:3001`.
 
-Env vars:
+## Env vars
+
 - `PORT` (default 3001)
 - `HOST` (default 0.0.0.0)
-- `CONFIG_DIR` (opsional) override path folder config (default: mencari folder `config/` dari parent directory)
+- `CONFIG_DIR` (opsional) override path folder config
 
 ## Endpoint
 
 - `GET /health`
 - `GET /api/config`
 - `GET /api/snapshot`
-- `POST /api/snapshot` (push snapshot dari producer)
 - `GET /api/controls`
 - `POST /api/controls/start`
 - `POST /api/controls/pause`
+- `POST /api/controls/stop`
 - `POST /api/controls/reset`
 - `POST /api/controls/consume-reset`
 
-## Contoh curl
+## Catatan
 
-```powershell
-curl http://localhost:3001/health
-curl http://localhost:3001/api/config
-curl http://localhost:3001/api/controls
-```
-
+- Snapshot di-generate otomatis saat backend start.
+- Status default mock runtime adalah `Running`.
+- Endpoint control tetap ada agar mudah dipakai untuk test/reset manual.

--- a/backend-eqfr/src/app.js
+++ b/backend-eqfr/src/app.js
@@ -20,7 +20,7 @@ function createApp({ configLoader, snapshotStore, controlStore }) {
   app.use(express.json({ limit: "1mb" }));
 
   app.use(createHealthRouter());
-  app.use("/api/config", createConfigRouter({ configLoader }));
+  app.use("/api/config", createConfigRouter({ configLoader, controlStore }));
   app.use("/api/snapshot", createSnapshotRouter({ snapshotStore }));
   app.use("/api/controls", createControlsRouter({ controlStore }));
 
@@ -40,4 +40,3 @@ function createApp({ configLoader, snapshotStore, controlStore }) {
 }
 
 module.exports = { createApp };
-

--- a/backend-eqfr/src/config/configLoader.js
+++ b/backend-eqfr/src/config/configLoader.js
@@ -1,44 +1,23 @@
 const fs = require("node:fs/promises");
 const path = require("node:path");
 
-const REQUIRED_FILES = [
-  "factory-layout.json",
-  "factory-routes.json",
-  "factory-process.json",
-  "factory-simulation.json",
-  "factory-transport.json"
-];
+const SECTION_FILE_MAP = {
+  layout: "factory-layout.json",
+  routes: "factory-routes.json",
+  process: "factory-process.json",
+  simulation: "factory-simulation.json",
+  transport: "factory-transport.json"
+};
+
+const REQUIRED_FILES = Object.values(SECTION_FILE_MAP);
 
 function createConfigLoader({ configDir }) {
   async function loadBundle() {
-    if (!configDir) {
-      const err = new Error("Config directory not found. Set CONFIG_DIR or ensure a 'config' folder exists.");
-      err.code = "CONFIG_DIR_NOT_FOUND";
-      throw err;
-    }
+    ensureConfigDir();
 
     const result = {};
-    for (const file of REQUIRED_FILES) {
-      const fullPath = path.join(configDir, file);
-      let raw;
-      try {
-        raw = await fs.readFile(fullPath, "utf8");
-      } catch (e) {
-        const err = new Error(`Missing config file: ${fullPath}`);
-        err.code = "CONFIG_FILE_MISSING";
-        err.cause = e;
-        throw err;
-      }
-
-      try {
-        const key = file.replace(".json", "").replace("factory-", "").replaceAll("-", "_");
-        result[key] = JSON.parse(raw);
-      } catch (e) {
-        const err = new Error(`Invalid JSON in config file: ${fullPath}`);
-        err.code = "CONFIG_JSON_INVALID";
-        err.cause = e;
-        throw err;
-      }
+    for (const [section, file] of Object.entries(SECTION_FILE_MAP)) {
+      result[section] = await readJsonFile(path.join(configDir, file));
     }
 
     return {
@@ -48,8 +27,66 @@ function createConfigLoader({ configDir }) {
     };
   }
 
-  return { loadBundle };
+  async function saveSection(section, payload) {
+    ensureConfigDir();
+
+    const normalizedSection = normalizeSection(section);
+    const file = SECTION_FILE_MAP[normalizedSection];
+    if (!file) {
+      const err = new Error(`Unsupported config section: '${section}'.`);
+      err.code = "CONFIG_SECTION_UNSUPPORTED";
+      throw err;
+    }
+
+    const fullPath = path.join(configDir, file);
+    const raw = `${JSON.stringify(payload, null, 2)}\n`;
+    await fs.writeFile(fullPath, raw, "utf8");
+
+    return {
+      section: normalizedSection,
+      file,
+      fullPath
+    };
+  }
+
+  return { loadBundle, saveSection };
+
+  function ensureConfigDir() {
+    if (!configDir) {
+      const err = new Error("Config directory not found. Set CONFIG_DIR or ensure a 'config' folder exists.");
+      err.code = "CONFIG_DIR_NOT_FOUND";
+      throw err;
+    }
+  }
+}
+
+async function readJsonFile(fullPath) {
+  let raw;
+  try {
+    raw = await fs.readFile(fullPath, "utf8");
+  } catch (e) {
+    const err = new Error(`Missing config file: ${fullPath}`);
+    err.code = "CONFIG_FILE_MISSING";
+    err.cause = e;
+    throw err;
+  }
+
+  try {
+    return JSON.parse(raw);
+  } catch (e) {
+    const err = new Error(`Invalid JSON in config file: ${fullPath}`);
+    err.code = "CONFIG_JSON_INVALID";
+    err.cause = e;
+    throw err;
+  }
+}
+
+function normalizeSection(section) {
+  return String(section || "")
+    .trim()
+    .toLowerCase()
+    .replaceAll("-", "_")
+    .replaceAll(" ", "_");
 }
 
 module.exports = { createConfigLoader };
-

--- a/backend-eqfr/src/mockFactoryRuntime.js
+++ b/backend-eqfr/src/mockFactoryRuntime.js
@@ -1,0 +1,714 @@
+const SIMULATION_STATUS = {
+  Stopped: 0,
+  Running: 1,
+  Paused: 2
+};
+
+const MACHINE_STATUS = {
+  Idle: 0,
+  WaitingForInput: 1,
+  Processing: 2,
+  OutputReady: 3,
+  Error: 99
+};
+
+const TRANSPORT_STATUS = {
+  Idle: 0,
+  Moving: 1,
+  Waiting: 2,
+  Loading: 3,
+  Unloading: 4,
+  Returning: 5,
+  Error: 99
+};
+
+const LOT_STATUS = {
+  Available: 0,
+  Reserved: 1,
+  InTransit: 2,
+  InProcess: 3,
+  Completed: 4,
+  Error: 99
+};
+
+const PORT_TYPE = {
+  Input: 0,
+  Output: 1
+};
+
+function createMockFactoryRuntime({ configLoader, snapshotStore, controlStore, logger = console }) {
+  let runtime = null;
+  let timer = null;
+  let configBundle = null;
+  let isTicking = false;
+
+  async function start() {
+    await refreshConfigBundle();
+    rebuildRuntime();
+    publishSnapshot();
+
+    const intervalMs = runtime.tickIntervalMs;
+    timer = setInterval(async () => {
+      if (isTicking) return;
+      isTicking = true;
+      try {
+        await tick();
+      } catch (error) {
+        logger.error("[backend-eqfr] mock runtime tick failed", error);
+      } finally {
+        isTicking = false;
+      }
+    }, intervalMs);
+  }
+
+  function stop() {
+    if (timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  }
+
+  async function tick() {
+    if (!runtime) return;
+
+    if (controlStore.consumeReset()) {
+      await refreshConfigBundle();
+      rebuildRuntime();
+    }
+
+    const controls = controlStore.get();
+    runtime.simulationStatus = toSimulationStatus(controls.desiredStatus);
+
+    if (runtime.simulationStatus === SIMULATION_STATUS.Running) {
+      advanceScenario();
+    }
+
+    publishSnapshot();
+  }
+
+  async function refreshConfigBundle() {
+    const loaded = await configLoader.loadBundle();
+    configBundle = loaded.bundle;
+  }
+
+  function rebuildRuntime() {
+    const layout = configBundle.layout;
+    const routes = configBundle.routes;
+    const process = configBundle.process;
+    const simulation = configBundle.simulation;
+    const transport = configBundle.transport;
+
+    const sourceLotSeed = simulation.initialLots?.[0] || {
+      lotId: "LOT_001",
+      materialType: "RAW",
+      locationId: layout.locations[0].id,
+      portId: layout.locations[0].ports?.[0]?.id || "OUT"
+    };
+
+    const machineConfig = process.machines[0];
+    const primaryTransport = transport.transports[0];
+    const secondaryTransport = transport.transports[1] || null;
+    const sourceLocationId = sourceLotSeed.locationId;
+    const sourcePortId = sourceLotSeed.portId;
+    const outputLocationId = findOutputWarehouse(layout.locations, sourceLocationId);
+    const outputPortId = findWarehouseInputPort(layout.locations, outputLocationId);
+
+    const routeEdges = routes.edges.map((edge, index) => ({
+      id: `EDGE_${String(index + 1).padStart(3, "0")}`,
+      fromLocationId: edge.from.locationId,
+      fromPortId: edge.from.portId,
+      toLocationId: edge.to.locationId,
+      toPortId: edge.to.portId,
+      isBidirectional: Boolean(edge.isBidirectional),
+      distance: edge.distance ?? null
+    }));
+
+    const graph = createGraph(routeEdges);
+
+    runtime = {
+      layout,
+      routeEdges,
+      graph,
+      simulationStatus: toSimulationStatus(controlStore.get().desiredStatus),
+      tickIntervalMs: simulation.tickIntervalMs || 250,
+      maxRecentEvents: simulation.maxRecentEvents || 200,
+      machineConfig,
+      machine: {
+        id: machineConfig.id,
+        inputPortId: machineConfig.inputPortId,
+        outputPortId: machineConfig.outputPortId,
+        status: MACHINE_STATUS.WaitingForInput,
+        currentLotId: null,
+        currentStepIndex: 0,
+        totalSteps: machineConfig.steps.length,
+        needsInput: true,
+        outputReady: false
+      },
+      transports: [
+        createTransportState(primaryTransport),
+        ...(secondaryTransport ? [createTransportState(secondaryTransport)] : [])
+      ],
+      primaryTransportId: primaryTransport.id,
+      secondaryTransportId: secondaryTransport?.id || primaryTransport.id,
+      sourceTemplate: sourceLotSeed,
+      sourceLocationId,
+      sourcePortId,
+      outputLocationId,
+      outputPortId,
+      activeLot: null,
+      completedLots: [],
+      recentEvents: [],
+      edgeOccupancy: {},
+      cycleNumber: 0,
+      taskCounter: 0,
+      processing: null,
+      travel: null,
+      phase: null
+    };
+
+    spawnNextLot();
+    transitionTo("announce-input");
+    addEvent(`Mock backend runtime initialized. Machine '${runtime.machine.id}' siap menerima input.`, runtime.machine.id, "mock.runtime.ready");
+  }
+
+  function createTransportState(config) {
+    return {
+      id: config.id,
+      status: TRANSPORT_STATUS.Idle,
+      locationId: config.start.locationId,
+      portId: config.start.portId,
+      currentTaskId: null,
+      currentLotId: null,
+      homeLocationId: config.start.locationId,
+      homePortId: config.start.portId
+    };
+  }
+
+  function transitionTo(kind) {
+    runtime.phase = { kind, remainingTicks: 0 };
+    runtime.edgeOccupancy = {};
+    runtime.travel = null;
+
+    switch (kind) {
+      case "announce-input":
+        runtime.phase.remainingTicks = 2;
+        runtime.machine.status = MACHINE_STATUS.WaitingForInput;
+        runtime.machine.currentLotId = null;
+        runtime.machine.currentStepIndex = 0;
+        runtime.machine.needsInput = true;
+        runtime.machine.outputReady = false;
+        inputTransport().status = TRANSPORT_STATUS.Idle;
+        inputTransport().currentTaskId = null;
+        inputTransport().currentLotId = null;
+        addEvent(`Machine '${runtime.machine.id}' requests input.`, runtime.machine.id, "machine.request_input");
+        break;
+
+      case "travel-to-input": {
+        const taskId = nextTaskId();
+        const path = findPath(inputTransport().id, inputTransport().locationId, runtime.sourceLocationId);
+        inputTransport().status = TRANSPORT_STATUS.Moving;
+        inputTransport().currentTaskId = taskId;
+        inputTransport().currentLotId = null;
+        runtime.phase.taskId = taskId;
+        runtime.travel = beginTravel(inputTransport().id, path, TRANSPORT_STATUS.Moving);
+        addEvent(`Dispatcher assigned '${inputTransport().id}' to deliver input lot '${runtime.activeLot.lotId}' -> machine '${runtime.machine.id}'.`, inputTransport().id, "dispatch.input.assigned");
+        addEvent(`Transport '${inputTransport().id}' started task '${taskId}'.`, inputTransport().id, "transport.task.started");
+        break;
+      }
+
+      case "pickup-input":
+        runtime.phase.remainingTicks = 2;
+        inputTransport().status = TRANSPORT_STATUS.Loading;
+        inputTransport().locationId = runtime.sourceLocationId;
+        inputTransport().portId = runtime.sourcePortId;
+        runtime.activeLot.status = LOT_STATUS.Reserved;
+        runtime.activeLot.locationId = runtime.sourceLocationId;
+        runtime.activeLot.portId = runtime.sourcePortId;
+        break;
+
+      case "travel-to-machine": {
+        const path = composePath(inputTransport().id, [runtime.sourceLocationId, inputTransport().homeLocationId, runtime.machine.id]);
+        inputTransport().status = TRANSPORT_STATUS.Moving;
+        inputTransport().currentLotId = runtime.activeLot.lotId;
+        runtime.activeLot.status = LOT_STATUS.InTransit;
+        runtime.travel = beginTravel(inputTransport().id, path, TRANSPORT_STATUS.Moving);
+        break;
+      }
+
+      case "drop-to-machine":
+        runtime.phase.remainingTicks = 2;
+        inputTransport().status = TRANSPORT_STATUS.Unloading;
+        inputTransport().locationId = runtime.machine.id;
+        inputTransport().portId = runtime.machine.inputPortId;
+        runtime.activeLot.locationId = runtime.machine.id;
+        runtime.activeLot.portId = runtime.machine.inputPortId;
+        runtime.activeLot.status = LOT_STATUS.InTransit;
+        break;
+
+      case "processing-step": {
+        const stepIndex = runtime.processing?.stepIndex ?? 0;
+        const step = runtime.machineConfig.steps[stepIndex];
+        runtime.phase.remainingTicks = Math.max(1, Math.ceil(step.durationMs / runtime.tickIntervalMs));
+        runtime.machine.status = MACHINE_STATUS.Processing;
+        runtime.machine.currentLotId = runtime.activeLot.lotId;
+        runtime.machine.currentStepIndex = stepIndex;
+        runtime.machine.needsInput = false;
+        runtime.activeLot.status = LOT_STATUS.InProcess;
+        runtime.activeLot.locationId = runtime.machine.id;
+        runtime.activeLot.portId = runtime.machine.inputPortId;
+        if (stepIndex === 0) {
+          addEvent(`Machine '${runtime.machine.id}' started lot '${runtime.activeLot.lotId}'. Step 1/${runtime.machine.totalSteps}: '${step.name}'.`, runtime.machine.id, "machine.lot.started");
+        } else {
+          addEvent(`Machine '${runtime.machine.id}' started step ${stepIndex + 1}/${runtime.machine.totalSteps}: '${step.name}'.`, runtime.machine.id, "machine.step.started");
+        }
+        break;
+      }
+
+      case "output-ready":
+        runtime.phase.remainingTicks = 2;
+        runtime.machine.status = MACHINE_STATUS.OutputReady;
+        runtime.machine.outputReady = true;
+        runtime.machine.needsInput = false;
+        runtime.activeLot.status = LOT_STATUS.Available;
+        runtime.activeLot.locationId = runtime.machine.id;
+        runtime.activeLot.portId = runtime.machine.outputPortId;
+        addEvent(`Machine '${runtime.machine.id}' completed lot '${runtime.activeLot.lotId}'. Output ready.`, runtime.machine.id, "machine.output.ready");
+        addEvent(`Dispatcher assigned '${outputTransport().id}' to move output lot '${runtime.activeLot.lotId}' -> warehouse '${runtime.outputLocationId}'.`, outputTransport().id, "dispatch.output.assigned");
+        break;
+
+      case "pickup-output": {
+        runtime.phase.remainingTicks = 2;
+        const taskId = nextTaskId();
+        const path = findPath(outputTransport().id, outputTransport().locationId, runtime.machine.id);
+        outputTransport().status = TRANSPORT_STATUS.Moving;
+        outputTransport().currentTaskId = taskId;
+        outputTransport().currentLotId = null;
+        runtime.phase.taskId = taskId;
+        runtime.travel = beginTravel(outputTransport().id, path, TRANSPORT_STATUS.Moving);
+        addEvent(`Transport '${outputTransport().id}' started task '${taskId}'.`, outputTransport().id, "transport.task.started");
+        break;
+      }
+
+      case "load-output":
+        runtime.phase.remainingTicks = 2;
+        outputTransport().status = TRANSPORT_STATUS.Loading;
+        outputTransport().locationId = runtime.machine.id;
+        outputTransport().portId = runtime.machine.outputPortId;
+        runtime.machine.outputReady = false;
+        break;
+
+      case "travel-to-output": {
+        const taskId = outputTransport().currentTaskId || nextTaskId();
+        const path = composePath(outputTransport().id, [runtime.machine.id, outputTransport().homeLocationId, runtime.outputLocationId]);
+        outputTransport().status = TRANSPORT_STATUS.Moving;
+        outputTransport().currentTaskId = taskId;
+        outputTransport().currentLotId = runtime.activeLot.lotId;
+        runtime.activeLot.status = LOT_STATUS.InTransit;
+        runtime.travel = beginTravel(outputTransport().id, path, TRANSPORT_STATUS.Moving);
+        break;
+      }
+
+      case "drop-to-output":
+        runtime.phase.remainingTicks = 2;
+        outputTransport().status = TRANSPORT_STATUS.Unloading;
+        outputTransport().locationId = runtime.outputLocationId;
+        outputTransport().portId = runtime.outputPortId;
+        runtime.activeLot.locationId = runtime.outputLocationId;
+        runtime.activeLot.portId = runtime.outputPortId;
+        break;
+
+      case "return-home": {
+        const path = findPath(outputTransport().id, runtime.outputLocationId, outputTransport().homeLocationId);
+        outputTransport().status = TRANSPORT_STATUS.Returning;
+        outputTransport().currentLotId = null;
+        outputTransport().currentTaskId = null;
+        runtime.travel = beginTravel(outputTransport().id, path, TRANSPORT_STATUS.Returning);
+        break;
+      }
+    }
+  }
+
+  function advanceScenario() {
+    switch (runtime.phase.kind) {
+      case "announce-input":
+        runtime.phase.remainingTicks -= 1;
+        if (runtime.phase.remainingTicks <= 0) transitionTo("travel-to-input");
+        break;
+
+      case "travel-to-input":
+        if (advanceTravel()) transitionTo("pickup-input");
+        break;
+
+      case "pickup-input":
+        runtime.phase.remainingTicks -= 1;
+        if (runtime.phase.remainingTicks <= 0) {
+          runtime.activeLot.status = LOT_STATUS.InTransit;
+          inputTransport().currentLotId = runtime.activeLot.lotId;
+          addEvent(`Transport '${inputTransport().id}' picked lot '${runtime.activeLot.lotId}'.`, inputTransport().id, "transport.pickup");
+          transitionTo("travel-to-machine");
+        }
+        break;
+
+      case "travel-to-machine":
+        if (advanceTravel()) transitionTo("drop-to-machine");
+        break;
+
+      case "drop-to-machine":
+        runtime.phase.remainingTicks -= 1;
+        if (runtime.phase.remainingTicks <= 0) {
+          addEvent(`Transport '${inputTransport().id}' dropped lot '${runtime.activeLot.lotId}'.`, inputTransport().id, "transport.dropoff");
+          addEvent(`Transport '${inputTransport().id}' completed task '${inputTransport().currentTaskId}'.`, inputTransport().id, "transport.task.completed");
+          runtime.processing = { stepIndex: 0 };
+          inputTransport().currentTaskId = null;
+          inputTransport().currentLotId = null;
+          transitionTo("processing-step");
+        }
+        break;
+
+      case "processing-step":
+        runtime.phase.remainingTicks -= 1;
+        if (runtime.phase.remainingTicks <= 0) {
+          const nextStepIndex = runtime.processing.stepIndex + 1;
+          if (nextStepIndex < runtime.machine.totalSteps) {
+            runtime.processing.stepIndex = nextStepIndex;
+            transitionTo("processing-step");
+          } else {
+            runtime.processing = null;
+            transitionTo("output-ready");
+          }
+        }
+        break;
+
+      case "output-ready":
+        runtime.phase.remainingTicks -= 1;
+        if (runtime.phase.remainingTicks <= 0) transitionTo("pickup-output");
+        break;
+
+      case "pickup-output":
+        if (advanceTravel()) transitionTo("load-output");
+        break;
+
+      case "load-output":
+        runtime.phase.remainingTicks -= 1;
+        if (runtime.phase.remainingTicks <= 0) {
+          outputTransport().currentLotId = runtime.activeLot.lotId;
+          addEvent(`Transport '${outputTransport().id}' picked lot '${runtime.activeLot.lotId}'.`, outputTransport().id, "transport.pickup");
+          addEvent(`Machine '${runtime.machine.id}' output cleared.`, runtime.machine.id, "machine.output.cleared");
+          transitionTo("travel-to-output");
+        }
+        break;
+
+      case "travel-to-output":
+        if (advanceTravel()) transitionTo("drop-to-output");
+        break;
+
+      case "drop-to-output":
+        runtime.phase.remainingTicks -= 1;
+        if (runtime.phase.remainingTicks <= 0) {
+          runtime.activeLot.status = LOT_STATUS.Completed;
+          runtime.completedLots = [runtime.activeLot, ...runtime.completedLots].slice(0, 5);
+          addEvent(`Transport '${outputTransport().id}' dropped lot '${runtime.activeLot.lotId}'.`, outputTransport().id, "transport.dropoff");
+          addEvent(`Transport '${outputTransport().id}' completed task '${outputTransport().currentTaskId}'.`, outputTransport().id, "transport.task.completed");
+          outputTransport().currentTaskId = null;
+          outputTransport().currentLotId = null;
+          spawnNextLot();
+          transitionTo("return-home");
+        }
+        break;
+
+      case "return-home":
+        if (advanceTravel()) transitionTo("announce-input");
+        break;
+    }
+  }
+
+  function advanceTravel() {
+    if (!runtime.travel) return true;
+
+    const travel = runtime.travel;
+    const transport = activeTravelTransport();
+    const currentIndex = travel.edgeIndex;
+    const fromLocationId = travel.path[currentIndex];
+    const toLocationId = travel.path[currentIndex + 1] || fromLocationId;
+    const edgeId = findEdgeId(fromLocationId, toLocationId);
+    runtime.edgeOccupancy = edgeId && transport ? { [edgeId]: transport.id } : {};
+
+    travel.ticksIntoEdge += 1;
+    if (travel.ticksIntoEdge < travel.ticksPerEdge || currentIndex + 1 >= travel.path.length) {
+      return false;
+    }
+
+    travel.ticksIntoEdge = 0;
+    travel.edgeIndex += 1;
+
+    if (transport) {
+      transport.locationId = travel.path[travel.edgeIndex];
+      transport.portId = resolvePortForLocation(transport, transport.locationId);
+    }
+
+    if (travel.edgeIndex >= travel.path.length - 1) {
+      runtime.edgeOccupancy = {};
+      runtime.travel = null;
+      return true;
+    }
+
+    return false;
+  }
+
+  function beginTravel(transportId, path, status) {
+    const transport = getTransportById(transportId);
+    const normalizedPath = Array.isArray(path) && path.length > 0
+      ? path
+      : [transport?.locationId || runtime.sourceLocationId];
+
+    if (transport) {
+      transport.status = status;
+      transport.locationId = normalizedPath[0];
+      transport.portId = resolvePortForLocation(transport, normalizedPath[0]);
+    }
+
+    return {
+      transportId,
+      path: normalizedPath,
+      edgeIndex: 0,
+      ticksIntoEdge: 0,
+      ticksPerEdge: 5
+    };
+  }
+
+  function composePath(transportId, checkpoints) {
+    const filtered = checkpoints.filter(Boolean);
+    if (filtered.length <= 1) {
+      return filtered;
+    }
+
+    const segments = [];
+    for (let i = 0; i < filtered.length - 1; i += 1) {
+      const segment = findPath(transportId, filtered[i], filtered[i + 1]);
+      if (segments.length === 0) {
+        segments.push(...segment);
+      } else {
+        segments.push(...segment.slice(1));
+      }
+    }
+
+    return segments;
+  }
+
+  function publishSnapshot() {
+    snapshotStore.set(buildSnapshot());
+  }
+
+  function buildSnapshot() {
+    const now = new Date().toISOString();
+    return {
+      serverTime: now,
+      simulationStatus: runtime.simulationStatus,
+      tickOptions: {
+        tickInterval: msToTimeSpan(runtime.tickIntervalMs),
+        maxRecentEvents: runtime.maxRecentEvents
+      },
+      locations: runtime.layout.locations.map((location) => ({
+        id: location.id,
+        displayName: location.displayName,
+        type: location.type,
+        x: location.position.x,
+        y: location.position.y,
+        ports: (location.ports || []).map((port) => ({
+          id: port.id,
+          type: PORT_TYPE[port.type] ?? PORT_TYPE.Output
+        }))
+      })),
+      routeEdges: runtime.routeEdges,
+      edgeOccupancy: runtime.edgeOccupancy,
+      machines: [
+        {
+          id: runtime.machine.id,
+          status: runtime.machine.status,
+          inputPortId: runtime.machine.inputPortId,
+          outputPortId: runtime.machine.outputPortId,
+          currentLotId: runtime.machine.currentLotId,
+          currentStepIndex: runtime.machine.currentStepIndex,
+          totalSteps: runtime.machine.totalSteps,
+          needsInput: runtime.machine.needsInput,
+          outputReady: runtime.machine.outputReady
+        }
+      ],
+      transports: runtime.transports.map((transport) => ({
+        id: transport.id,
+        status: transport.status,
+        locationId: transport.locationId,
+        portId: transport.portId,
+        currentTaskId: transport.currentTaskId,
+        currentLotId: transport.currentLotId
+      })),
+      lots: [
+        ...(runtime.activeLot ? [runtime.activeLot] : []),
+        ...runtime.completedLots
+      ].map((lot) => ({
+        lotId: lot.lotId,
+        materialType: lot.materialType,
+        status: lot.status,
+        locationId: lot.locationId,
+        portId: lot.portId
+      })),
+      recentEvents: runtime.recentEvents
+    };
+  }
+
+  function spawnNextLot() {
+    runtime.cycleNumber += 1;
+    const lotId = runtime.cycleNumber === 1
+      ? runtime.sourceTemplate.lotId
+      : nextLotId(runtime.sourceTemplate.lotId, runtime.cycleNumber);
+
+    runtime.activeLot = {
+      lotId,
+      materialType: runtime.sourceTemplate.materialType,
+      status: LOT_STATUS.Available,
+      locationId: runtime.sourceLocationId,
+      portId: runtime.sourcePortId
+    };
+  }
+
+  function nextTaskId() {
+    runtime.taskCounter += 1;
+    return `TASK_${String(runtime.taskCounter).padStart(4, "0")}`;
+  }
+
+  function nextLotId(seedLotId, cycleNumber) {
+    const match = /^(.*?)(\d+)$/.exec(seedLotId);
+    if (!match) return `${seedLotId}_${String(cycleNumber).padStart(3, "0")}`;
+    const [, prefix, numericPart] = match;
+    const nextValue = Number.parseInt(numericPart, 10) + cycleNumber - 1;
+    return `${prefix}${String(nextValue).padStart(numericPart.length, "0")}`;
+  }
+
+  function primaryTransport() {
+    return runtime.transports.find((item) => item.id === runtime.primaryTransportId);
+  }
+
+  function inputTransport() {
+    return primaryTransport();
+  }
+
+  function outputTransport() {
+    return runtime.transports.find((item) => item.id === runtime.secondaryTransportId) || primaryTransport();
+  }
+
+  function getTransportById(transportId) {
+    return runtime.transports.find((item) => item.id === transportId) || null;
+  }
+
+  function activeTravelTransport() {
+    return runtime.travel ? getTransportById(runtime.travel.transportId) : null;
+  }
+
+  function resolvePortForLocation(transport, locationId) {
+    if (locationId === runtime.machine.id) {
+      return transport?.id === runtime.secondaryTransportId
+        ? runtime.machine.outputPortId
+        : runtime.machine.inputPortId;
+    }
+
+    if (locationId === runtime.sourceLocationId) return runtime.sourcePortId;
+    if (locationId === runtime.outputLocationId) return runtime.outputPortId;
+    if (locationId === transport?.homeLocationId) return transport.homePortId;
+
+    const location = runtime.layout.locations.find((item) => item.id === locationId);
+    return location?.ports?.[0]?.id || "IN";
+  }
+
+  function addEvent(message, entityId = null, eventType = null) {
+    runtime.recentEvents.unshift({
+      timestamp: new Date().toISOString(),
+      message,
+      entityId,
+      eventType
+    });
+    runtime.recentEvents = runtime.recentEvents.slice(0, runtime.maxRecentEvents);
+  }
+
+  function findPath(transportId, fromLocationId, toLocationId) {
+    if (fromLocationId === toLocationId) return [fromLocationId];
+
+    const allowedLocations = getAllowedLocationsForTransport(transportId);
+    const queue = [[fromLocationId]];
+    const visited = new Set([fromLocationId]);
+
+    while (queue.length > 0) {
+      const currentPath = queue.shift();
+      const current = currentPath[currentPath.length - 1];
+      const neighbors = runtime.graph.get(current) || [];
+      for (const next of neighbors) {
+        if (allowedLocations && !allowedLocations.has(next)) continue;
+        if (visited.has(next)) continue;
+        const nextPath = [...currentPath, next];
+        if (next === toLocationId) return nextPath;
+        visited.add(next);
+        queue.push(nextPath);
+      }
+    }
+
+    return [fromLocationId, toLocationId];
+  }
+
+  function getAllowedLocationsForTransport(transportId) {
+    if (transportId === runtime.primaryTransportId) {
+      return new Set([runtime.sourceLocationId, "CS_1", runtime.machine.id]);
+    }
+
+    if (transportId === runtime.secondaryTransportId) {
+      return new Set([runtime.machine.id, "CS_2", runtime.outputLocationId]);
+    }
+
+    return null;
+  }
+
+  function findEdgeId(fromLocationId, toLocationId) {
+    const direct = runtime.routeEdges.find((edge) => edge.fromLocationId === fromLocationId && edge.toLocationId === toLocationId);
+    if (direct) return direct.id;
+    const reverse = runtime.routeEdges.find((edge) => edge.isBidirectional && edge.fromLocationId === toLocationId && edge.toLocationId === fromLocationId);
+    return reverse?.id || null;
+  }
+
+  return { start, stop };
+}
+
+function createGraph(routeEdges) {
+  const graph = new Map();
+  for (const edge of routeEdges) {
+    if (!graph.has(edge.fromLocationId)) graph.set(edge.fromLocationId, []);
+    graph.get(edge.fromLocationId).push(edge.toLocationId);
+    if (edge.isBidirectional) {
+      if (!graph.has(edge.toLocationId)) graph.set(edge.toLocationId, []);
+      graph.get(edge.toLocationId).push(edge.fromLocationId);
+    }
+  }
+  return graph;
+}
+
+function toSimulationStatus(value) {
+  return SIMULATION_STATUS[value] ?? SIMULATION_STATUS.Running;
+}
+
+function findOutputWarehouse(locations, sourceLocationId) {
+  const candidate = locations.find((location) => location.type === "Warehouse" && location.id !== sourceLocationId && (location.ports || []).some((port) => port.type === "Input"));
+  return candidate?.id || sourceLocationId;
+}
+
+function findWarehouseInputPort(locations, warehouseId) {
+  const warehouse = locations.find((location) => location.id === warehouseId);
+  return warehouse?.ports?.find((port) => port.type === "Input")?.id || warehouse?.ports?.[0]?.id || "IN";
+}
+
+function msToTimeSpan(ms) {
+  const totalMilliseconds = Math.max(0, Number(ms) || 0);
+  const hours = Math.floor(totalMilliseconds / 3600000);
+  const minutes = Math.floor((totalMilliseconds % 3600000) / 60000);
+  const seconds = Math.floor((totalMilliseconds % 60000) / 1000);
+  const milliseconds = totalMilliseconds % 1000;
+  return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}.${String(milliseconds).padStart(3, "0")}0000`;
+}
+
+module.exports = { createMockFactoryRuntime };

--- a/backend-eqfr/src/routes/configRoutes.js
+++ b/backend-eqfr/src/routes/configRoutes.js
@@ -1,17 +1,31 @@
 const express = require("express");
 
-function createConfigRouter({ configLoader }) {
+function createConfigRouter({ configLoader, controlStore }) {
   const router = express.Router();
 
-  router.get("/", async (req, res, next) => {
+  router.get("/", async (req, res) => {
     try {
       const data = await configLoader.loadBundle();
       res.json(data);
     } catch (e) {
-      // Use 500 for MVP, but include a stable error code for debugging.
       res.status(500).json({
         error: e && e.code ? e.code : "CONFIG_LOAD_FAILED",
         message: e && e.message ? e.message : "Failed to load config"
+      });
+    }
+  });
+
+  router.post("/:section", async (req, res) => {
+    try {
+      const saved = await configLoader.saveSection(req.params.section, req.body);
+      controlStore.reset();
+      const data = await configLoader.loadBundle();
+      res.json({ ok: true, saved, resetRequested: true, ...data });
+    } catch (e) {
+      const status = e && e.code === "CONFIG_SECTION_UNSUPPORTED" ? 400 : 500;
+      res.status(status).json({
+        error: e && e.code ? e.code : "CONFIG_SAVE_FAILED",
+        message: e && e.message ? e.message : "Failed to save config"
       });
     }
   });
@@ -20,4 +34,3 @@ function createConfigRouter({ configLoader }) {
 }
 
 module.exports = { createConfigRouter };
-

--- a/backend-eqfr/src/server.js
+++ b/backend-eqfr/src/server.js
@@ -6,28 +6,43 @@ const { findConfigDirectory } = require("./config/findConfigDirectory");
 const { createConfigLoader } = require("./config/configLoader");
 const { createSnapshotStore } = require("./state/snapshotStore");
 const { createControlStore } = require("./state/controlStore");
+const { createMockFactoryRuntime } = require("./mockFactoryRuntime");
 
-const host = process.env.HOST || "0.0.0.0";
-const port = Number.parseInt(process.env.PORT || "3001", 10);
+async function main() {
+  const host = process.env.HOST || "0.0.0.0";
+  const port = Number.parseInt(process.env.PORT || "3001", 10);
 
-const configDir =
-  process.env.CONFIG_DIR ||
-  findConfigDirectory(path.resolve(__dirname, "..", "..")) ||
-  null;
+  const configDir =
+    process.env.CONFIG_DIR ||
+    findConfigDirectory(path.resolve(__dirname, "..", "..")) ||
+    null;
 
-const configLoader = createConfigLoader({ configDir });
-const snapshotStore = createSnapshotStore();
-const controlStore = createControlStore();
+  const configLoader = createConfigLoader({ configDir });
+  const snapshotStore = createSnapshotStore();
+  const controlStore = createControlStore();
+  const runtime = createMockFactoryRuntime({ configLoader, snapshotStore, controlStore, logger: console });
 
-const app = createApp({ configLoader, snapshotStore, controlStore });
+  await runtime.start();
 
-const server = http.createServer(app);
+  const app = createApp({ configLoader, snapshotStore, controlStore });
+  const server = http.createServer(app);
 
-server.listen(port, host, () => {
-  const resolvedConfigDir = configDir || "(not found)";
-  // eslint-disable-next-line no-console
-  console.log(`[backend-eqfr] listening on http://${host}:${port}`);
-  // eslint-disable-next-line no-console
-  console.log(`[backend-eqfr] configDir: ${resolvedConfigDir}`);
+  server.listen(port, host, () => {
+    const resolvedConfigDir = configDir || "(not found)";
+    console.log(`[backend-eqfr] listening on http://${host}:${port}`);
+    console.log(`[backend-eqfr] configDir: ${resolvedConfigDir}`);
+  });
+
+  const shutdown = () => {
+    runtime.stop();
+    server.close(() => process.exit(0));
+  };
+
+  process.on("SIGINT", shutdown);
+  process.on("SIGTERM", shutdown);
+}
+
+main().catch((error) => {
+  console.error("[backend-eqfr] failed to start", error);
+  process.exit(1);
 });
-

--- a/backend-eqfr/src/state/controlStore.js
+++ b/backend-eqfr/src/state/controlStore.js
@@ -1,7 +1,7 @@
 const VALID_STATUSES = ["Stopped", "Running", "Paused"];
 
 function createControlStore() {
-  let desiredStatus = "Stopped";
+  let desiredStatus = "Running";
   let resetRequested = false;
   let lastChangedUtc = new Date().toISOString();
 
@@ -33,6 +33,7 @@ function createControlStore() {
 
   function reset() {
     resetRequested = true;
+    desiredStatus = "Running";
     lastChangedUtc = new Date().toISOString();
   }
 
@@ -47,4 +48,3 @@ function createControlStore() {
 }
 
 module.exports = { createControlStore };
-

--- a/config/factory-routes.json
+++ b/config/factory-routes.json
@@ -7,29 +7,22 @@
       "distance": 2
     },
     {
-      "from": { "locationId": "WH_IN", "portId": "OUT" },
+      "from": { "locationId": "CS_1", "portId": "IN" },
       "to": { "locationId": "ROLL_PRESS_1", "portId": "IN" },
       "isBidirectional": true,
       "distance": 2
     },
     {
       "from": { "locationId": "ROLL_PRESS_1", "portId": "OUT" },
-      "to": { "locationId": "WH_OUT", "portId": "IN" },
-      "isBidirectional": true,
-      "distance": 4
-    },
-    {
-      "from": { "locationId": "WH_OUT", "portId": "IN" },
       "to": { "locationId": "CS_2", "portId": "IN" },
       "isBidirectional": true,
       "distance": 2
     },
     {
       "from": { "locationId": "CS_2", "portId": "IN" },
-      "to": { "locationId": "CS_1", "portId": "IN" },
+      "to": { "locationId": "WH_OUT", "portId": "IN" },
       "isBidirectional": true,
-      "distance": 4
+      "distance": 2
     }
   ]
 }
-

--- a/src/EQFR.Common/EQFR.Common.csproj
+++ b/src/EQFR.Common/EQFR.Common.csproj
@@ -1,9 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
 </Project>

--- a/src/EQFR.IO/Config/JsonConfigLoader.cs
+++ b/src/EQFR.IO/Config/JsonConfigLoader.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using EQFR.Common;
 using EQFR.EIFData.Layout;
 using EQFR.EIFData.Process;
@@ -12,7 +13,8 @@ public sealed class JsonConfigLoader : IConfigLoader
 {
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
-        PropertyNameCaseInsensitive = true
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
     };
 
     public Result<ConfigBundle> LoadFromDirectory(string configDirectory)

--- a/src/EQFR.UI/Components/ConfigEditorPanel.razor
+++ b/src/EQFR.UI/Components/ConfigEditorPanel.razor
@@ -1,0 +1,144 @@
+@using EQFR.UI.Services
+@inject FactoryConfigService ConfigService
+
+<section class="panel panel--config glass floatingCard @(Minimized ? "floatingCard--min" : string.Empty)">
+    <div class="panel__head">
+        <h2>Config Editor</h2>
+        <div class="panel__headActions">
+            <div class="panel__meta">@StatusText</div>
+            <button type="button" class="floatingCard__toggle" @onclick="OnToggleMinimized">@(Minimized ? "+" : "-")</button>
+        </div>
+    </div>
+
+    @if (!Minimized)
+    {
+        <div class="panel__body configEditor">
+            <div class="configEditor__toolbar">
+                <label class="configEditor__field">
+                    <span>Section</span>
+                    <select @bind="SelectedSection" class="configEditor__select">
+                        @foreach (var item in Sections)
+                        {
+                            <option value="@item.Key">@item.Value</option>
+                        }
+                    </select>
+                </label>
+
+                <button type="button" class="configEditor__button" @onclick="LoadAsync" disabled="@IsBusy">Reload</button>
+                <button type="button" class="configEditor__button configEditor__button--primary" @onclick="SaveAsync" disabled="@IsBusy">Save + Reset</button>
+            </div>
+
+            <div class="configEditor__meta">
+                <span>Config dir: @ConfigDir</span>
+            </div>
+
+            <textarea class="configEditor__textarea" @bind="EditorText" @bind:event="oninput" spellcheck="false"></textarea>
+        </div>
+    }
+</section>
+
+@code {
+    [Parameter] public bool Minimized { get; set; }
+    [Parameter] public EventCallback OnToggleMinimized { get; set; }
+
+    private static readonly IReadOnlyDictionary<string, string> Sections = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["layout"] = "Layout",
+        ["routes"] = "Rules / Routes",
+        ["transport"] = "Transport",
+        ["process"] = "Process",
+        ["simulation"] = "Simulation"
+    };
+
+    private Dictionary<string, string> _sectionText = new(StringComparer.OrdinalIgnoreCase);
+    private string _selectedSection = "layout";
+    private string _editorText = "{}";
+
+    private bool IsBusy { get; set; }
+    private string StatusText { get; set; } = "Not loaded";
+    private string ConfigDir { get; set; } = "-";
+
+    private string SelectedSection
+    {
+        get => _selectedSection;
+        set
+        {
+            _selectedSection = value;
+            if (_sectionText.TryGetValue(value, out var text))
+            {
+                _editorText = text;
+            }
+        }
+    }
+
+    private string EditorText
+    {
+        get => _editorText;
+        set
+        {
+            _editorText = value;
+            _sectionText[_selectedSection] = value;
+        }
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadCoreAsync(ignoreBusy: false);
+    }
+
+    private Task LoadAsync() => LoadCoreAsync(ignoreBusy: false);
+
+    private async Task LoadCoreAsync(bool ignoreBusy)
+    {
+        if (IsBusy && !ignoreBusy) return;
+
+        IsBusy = true;
+        StatusText = "Loading...";
+        try
+        {
+            var bundle = await ConfigService.GetAsync();
+            _sectionText = bundle.Sections.ToDictionary(kvp => kvp.Key, kvp => kvp.Value ?? "{}", StringComparer.OrdinalIgnoreCase);
+            ConfigDir = string.IsNullOrWhiteSpace(bundle.ConfigDir) ? "-" : bundle.ConfigDir;
+
+            if (!_sectionText.TryGetValue(_selectedSection, out var currentText))
+            {
+                _selectedSection = Sections.Keys.First();
+                currentText = _sectionText.GetValueOrDefault(_selectedSection, "{}");
+            }
+
+            _editorText = currentText ?? "{}";
+            StatusText = "Loaded";
+        }
+        catch (Exception ex)
+        {
+            StatusText = $"Load failed: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private async Task SaveAsync()
+    {
+        if (IsBusy) return;
+
+        IsBusy = true;
+        StatusText = "Saving...";
+        try
+        {
+            await ConfigService.SaveSectionAsync(_selectedSection, _editorText);
+            IsBusy = false;
+            await LoadCoreAsync(ignoreBusy: true);
+            StatusText = "Saved. Runtime reset requested.";
+        }
+        catch (Exception ex)
+        {
+            StatusText = $"Save failed: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+}

--- a/src/EQFR.UI/Components/ConfigEditorPanel.razor.css
+++ b/src/EQFR.UI/Components/ConfigEditorPanel.razor.css
@@ -1,0 +1,83 @@
+.panel--config {
+  position: absolute;
+  right: 20px;
+  left: 20px;
+  bottom: 20px;
+  min-height: 280px;
+  max-height: 34vh;
+}
+
+.configEditor {
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr);
+  gap: 12px;
+}
+
+.configEditor__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: end;
+}
+
+.configEditor__field {
+  display: grid;
+  gap: 6px;
+  min-width: 180px;
+  color: #475569;
+  font-size: 12px;
+}
+
+.configEditor__select,
+.configEditor__button {
+  min-height: 36px;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  background: rgba(255, 255, 255, 0.8);
+  color: #0f172a;
+}
+
+.configEditor__select {
+  padding: 0 10px;
+}
+
+.configEditor__button {
+  padding: 0 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.configEditor__button--primary {
+  background: linear-gradient(135deg, #0f766e, #0891b2);
+  border-color: transparent;
+  color: #f8fafc;
+}
+
+.configEditor__meta {
+  color: #64748b;
+  font-size: 12px;
+}
+
+.configEditor__textarea {
+  width: 100%;
+  min-height: 180px;
+  resize: vertical;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  background: rgba(15, 23, 42, 0.92);
+  color: #dbeafe;
+  padding: 12px 14px;
+  font: 12px/1.5 Consolas, "Courier New", monospace;
+}
+
+@media (max-width: 1180px) {
+  .panel--config {
+    position: relative;
+    right: auto;
+    left: auto;
+    bottom: auto;
+    max-height: none;
+    min-height: 320px;
+    margin-top: 14px;
+  }
+}

--- a/src/EQFR.UI/Components/FactoryCanvas.razor
+++ b/src/EQFR.UI/Components/FactoryCanvas.razor
@@ -1,3 +1,4 @@
+@using System.Globalization
 @using EQFR.UI.ViewModels
 
 @if (Scene is null)
@@ -6,43 +7,62 @@
 }
 else
 {
-    <svg class="fc" viewBox="@($"{Scene.MinX} {Scene.MinY} {Scene.Width} {Scene.Height}")" role="img" aria-label="Factory canvas">
-        <defs>
-            <filter id="fcShadow" x="-20%" y="-20%" width="140%" height="140%">
-                <feDropShadow dx="0" dy="0.08" stdDeviation="0.12" flood-color="rgba(16,24,40,0.25)" />
-            </filter>
-        </defs>
+    <div class="fc__viewport" style="@ViewportStyle">
+        <svg class="fc" viewBox="@ViewBox(Scene)" role="img" aria-label="Factory canvas">
+            <defs>
+                <filter id="fcShadow" x="-20%" y="-20%" width="140%" height="140%">
+                    <feDropShadow dx="0" dy="0.08" stdDeviation="0.12" flood-color="rgba(16,24,40,0.25)" />
+                </filter>
+            </defs>
 
-        @foreach (var e in Scene.Edges)
-        {
-            <line x1="@e.X1" y1="@e.Y1" x2="@e.X2" y2="@e.Y2" class="fc__edge @(e.IsOccupied ? "fc__edge--occ" : "")" />
-        }
+            @foreach (var e in Scene.Edges)
+            {
+                <line x1="@Svg(e.X1)" y1="@Svg(e.Y1)" x2="@Svg(e.X2)" y2="@Svg(e.Y2)" class="fc__edge @(e.IsOccupied ? "fc__edge--occ" : "")" />
+            }
 
-        @foreach (var n in Scene.Nodes)
-        {
-            <g class="fc__node" transform="@($"translate({n.X},{n.Y})")">
-                <circle r="0.45" class="fc__nodeDot @(NodeKindClass(n.Type))" filter="url(#fcShadow)" />
-                <text class="fc__nodeLabel" x="0.6" y="0.1">@n.Id</text>
-            </g>
-        }
+            @foreach (var n in Scene.Nodes)
+            {
+                var subLabel = string.Equals(n.DisplayName, n.Id, StringComparison.OrdinalIgnoreCase) ? string.Empty : n.Id;
+                <g class="fc__node" transform="@Translate(n.X, n.Y)">
+                    <circle r="0.45" class="fc__nodeDot @(NodeKindClass(n.Type))" filter="url(#fcShadow)" />
+                    <text class="fc__nodeLabel" x="0.6" y="0.1">@n.DisplayName</text>
+                    <text class="fc__nodeSubLabel @(string.IsNullOrWhiteSpace(subLabel) ? "fc__nodeSubLabel--hidden" : string.Empty)" x="0.6" y="0.46">@subLabel</text>
+                </g>
+            }
 
-        @foreach (var m in Scene.Machines)
-        {
-            <circle cx="@m.X" cy="@m.Y" r="0.62" class="fc__machineRing @(MachineStatusClass(m.Status))" />
-        }
+            @foreach (var m in Scene.Machines)
+            {
+                <circle cx="@Svg(m.X)" cy="@Svg(m.Y)" r="0.62" class="fc__machineRing @(MachineStatusClass(m.Status))" />
+            }
 
-        @foreach (var t in Scene.Transports)
-        {
-            <g class="fc__transport" transform="@($"translate({t.X},{t.Y})")">
-                <circle r="0.22" class="fc__transportDot @(TransportStatusClass(t.Status))" filter="url(#fcShadow)" />
-                <text class="fc__transportLabel" x="0.28" y="-0.28">@t.Id</text>
-            </g>
-        }
-    </svg>
+            @foreach (var t in Scene.Transports)
+            {
+                <g class="fc__transport" transform="@Translate(t.X, t.Y)">
+                    <circle r="0.22" class="fc__transportDot @(TransportStatusClass(t.Status))" filter="url(#fcShadow)" />
+                    <text class="fc__transportLabel" x="0.28" y="-0.28">@t.Id</text>
+                </g>
+            }
+        </svg>
+    </div>
 }
 
 @code {
     [Parameter] public FactoryCanvasViewModel.Scene? Scene { get; set; }
+    [Parameter] public double Zoom { get; set; } = 1d;
+
+    private string ViewportStyle => string.Create(
+        CultureInfo.InvariantCulture,
+        $"transform: scale({Math.Clamp(Zoom, 0.6d, 2.4d)});");
+
+    private static string Svg(double value) => value.ToString(CultureInfo.InvariantCulture);
+
+    private static string ViewBox(FactoryCanvasViewModel.Scene scene) => string.Create(
+        CultureInfo.InvariantCulture,
+        $"{scene.MinX} {scene.MinY} {scene.Width} {scene.Height}");
+
+    private static string Translate(double x, double y) => string.Create(
+        CultureInfo.InvariantCulture,
+        $"translate({x},{y})");
 
     private static string NodeKindClass(string type)
     {
@@ -72,4 +92,3 @@ else
         _ => "fc__transportDot--idle"
     };
 }
-

--- a/src/EQFR.UI/Components/FactoryCanvas.razor.css
+++ b/src/EQFR.UI/Components/FactoryCanvas.razor.css
@@ -1,7 +1,21 @@
+.fc__viewport {
+  width: 100%;
+  height: 100%;
+  transform-origin: center center;
+  transition: transform 280ms ease;
+}
+
 .fc {
   width: 100%;
   height: 100%;
   display: block;
+  border-radius: 28px;
+  background:
+    linear-gradient(180deg, rgba(248, 250, 252, 0.92), rgba(226, 232, 240, 0.74)),
+    radial-gradient(circle at top left, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0));
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.72),
+    0 30px 60px rgba(15, 23, 42, 0.12);
 }
 
 .fc__empty {
@@ -11,6 +25,9 @@
   place-items: center;
   color: #516072;
   font-size: 14px;
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.56);
+  backdrop-filter: blur(10px);
 }
 
 .fc__edge {
@@ -26,7 +43,17 @@
 
 .fc__nodeLabel {
   font-size: 0.32px;
-  fill: rgba(37, 49, 62, 0.85);
+  font-weight: 700;
+  fill: rgba(37, 49, 62, 0.9);
+}
+
+.fc__nodeSubLabel {
+  font-size: 0.22px;
+  fill: rgba(71, 85, 105, 0.9);
+}
+
+.fc__nodeSubLabel--hidden {
+  display: none;
 }
 
 .fc__nodeDot {
@@ -68,4 +95,3 @@
 .fc__transportDot--unloading { fill: #14b8a6; }
 .fc__transportDot--returning { fill: #0ea5e9; }
 .fc__transportDot--error { fill: #ef4444; }
-

--- a/src/EQFR.UI/Components/Layout/MainLayout.razor
+++ b/src/EQFR.UI/Components/Layout/MainLayout.razor
@@ -1,9 +1,16 @@
-﻿@inherits LayoutComponentBase
+@inherits LayoutComponentBase
 
-@Body
+<div class="appShell">
+    <nav class="appNav glass">
+        <a href="/dashboard" class="appNav__link">Dashboard</a>
+        <a href="/layout-builder" class="appNav__link">Layout Builder</a>
+    </nav>
+
+    @Body
+</div>
 
 <div id="blazor-error-ui" data-nosnippet>
     An unhandled error has occurred.
     <a href="." class="reload">Reload</a>
-    <span class="dismiss">🗙</span>
+    <span class="dismiss">??</span>
 </div>

--- a/src/EQFR.UI/Components/Layout/MainLayout.razor.css
+++ b/src/EQFR.UI/Components/Layout/MainLayout.razor.css
@@ -1,3 +1,43 @@
+.appShell {
+    min-height: 100vh;
+}
+
+.appNav {
+    position: fixed;
+    top: 14px;
+    left: 50%;
+    z-index: 100;
+    display: inline-flex;
+    gap: 8px;
+    padding: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.55);
+    border-radius: 999px;
+    transform: translateX(-50%);
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+}
+
+.appNav__link {
+    display: inline-flex;
+    align-items: center;
+    min-height: 34px;
+    padding: 0 14px;
+    border-radius: 999px;
+    color: #0f172a;
+    text-decoration: none;
+    font-size: 12px;
+    font-weight: 700;
+    background: rgba(255, 255, 255, 0.72);
+}
+
+.appNav__link:hover {
+    background: rgba(255, 255, 255, 0.92);
+}
+
+.glass {
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.72), rgba(255, 255, 255, 0.52));
+    backdrop-filter: blur(18px);
+}
+
 #blazor-error-ui {
     color-scheme: light only;
     background: lightyellow;
@@ -12,9 +52,9 @@
     z-index: 1000;
 }
 
-    #blazor-error-ui .dismiss {
-        cursor: pointer;
-        position: absolute;
-        right: 0.75rem;
-        top: 0.5rem;
-    }
+#blazor-error-ui .dismiss {
+    cursor: pointer;
+    position: absolute;
+    right: 0.75rem;
+    top: 0.5rem;
+}

--- a/src/EQFR.UI/Components/Pages/Dashboard.razor
+++ b/src/EQFR.UI/Components/Pages/Dashboard.razor
@@ -7,10 +7,29 @@
 
 <PageTitle>Dashboard</PageTitle>
 
-<div class="dash">
-    <header class="dash__header">
-        <div class="dash__title">
-            <h1>EQFR Dashboard</h1>
+<div class="@(CanvasOnly ? "dash dash--canvasOnly" : "dash")">
+    <section class="dash__canvas">
+        <div class="dash__canvasToolbar glass">
+            <button type="button" class="dash__zoomButton" @onclick="ZoomOut" aria-label="Zoom out">-</button>
+            <div class="dash__zoomValue">@($"{(ZoomLevel * 100):0}%")</div>
+            <button type="button" class="dash__zoomButton" @onclick="ZoomIn" aria-label="Zoom in">+</button>
+            <button type="button" class="dash__zoomReset" @onclick="ResetZoom">Reset</button>
+            <button type="button" class="dash__zoomReset" @onclick="ToggleCanvasOnly">@(CanvasOnly ? "Show Panels" : "Canvas Only")</button>
+        </div>
+        <FactoryCanvas Scene="@(FactoryCanvasViewModel.Build(Vm.Snapshot))" Zoom="@ZoomLevel" />
+    </section>
+
+    <header class="dash__hero glass floatingCard @(HeroMinimized ? "floatingCard--min" : string.Empty)">
+        <div class="floatingCard__head">
+            <div>
+                <div class="dash__eyebrow">Realtime Factory</div>
+                <h1>EQFR Live Monitor</h1>
+            </div>
+            <button type="button" class="floatingCard__toggle" @onclick="(() => HeroMinimized = !HeroMinimized)">@(HeroMinimized ? "+" : "-")</button>
+        </div>
+
+        @if (!HeroMinimized)
+        {
             <div class="dash__subtitle">
                 @if (Vm.LastUpdated is null)
                 {
@@ -21,60 +40,77 @@
                     <span>Last update (UTC): @Vm.LastUpdated</span>
                 }
             </div>
-        </div>
-        <div class="dash__controls">
-            <button class="btn @(Vm.CanStart ? "" : "btn--disabled")" disabled="@(!Vm.CanStart)" @onclick="Vm.StartAsync">Start</button>
-            <button class="btn @(Vm.CanPause ? "" : "btn--disabled")" disabled="@(!Vm.CanPause)" @onclick="Vm.PauseAsync">Pause</button>
-            <button class="btn @(Vm.CanReset ? "" : "btn--disabled")" disabled="@(!Vm.CanReset)" @onclick="Vm.ResetAsync">Reset</button>
-        </div>
+            <div class="dash__status">
+                <span class="badge badge--live">Auto Run</span>
+                <span class="badge">@Vm.SimulationStatus</span>
+            </div>
+        }
     </header>
 
-    <main class="dash__grid">
-        <section class="panel panel--canvas">
-            <div class="panel__head">
-                <h2>Factory Canvas</h2>
-                <div class="panel__meta">Realtime</div>
-            </div>
-            <div class="panel__body canvas">
-                <FactoryCanvas Scene="@(FactoryCanvasViewModel.Build(Vm.Snapshot))" />
-            </div>
-        </section>
+    <section class="dash__summary glass floatingCard @(SummaryMinimized ? "floatingCard--min" : string.Empty)">
+        <div class="floatingCard__head">
+            <h2 class="floatingCard__title">Summary</h2>
+            <button type="button" class="floatingCard__toggle" @onclick="(() => SummaryMinimized = !SummaryMinimized)">@(SummaryMinimized ? "+" : "-")</button>
+        </div>
 
-        <section class="panel">
-            <div class="panel__head">
-                <h2>Machine</h2>
-                <div class="panel__meta">@((Vm.Snapshot?.Machines.Count ?? 0).ToString())</div>
+        @if (!SummaryMinimized)
+        {
+            <div class="kpi">
+                <div class="kpi__label">Machines</div>
+                <div class="kpi__value">@((Vm.Snapshot?.Machines.Count ?? 0).ToString("00"))</div>
             </div>
-            <div class="panel__body">
-                <MachinePanel Items="@(MachinePanelViewModel.Build(Vm.Snapshot))" />
+            <div class="kpi">
+                <div class="kpi__label">Transport</div>
+                <div class="kpi__value">@((Vm.Snapshot?.Transports.Count ?? 0).ToString("00"))</div>
             </div>
-        </section>
+            <div class="kpi">
+                <div class="kpi__label">Events</div>
+                <div class="kpi__value">@((Vm.Snapshot?.RecentEvents.Count ?? 0).ToString("00"))</div>
+            </div>
+        }
+    </section>
 
-        <section class="panel">
+    <aside class="dash__side floatingCard @(SideMinimized ? "floatingCard--min" : string.Empty)">
+        <div class="panel glass">
             <div class="panel__head">
-                <h2>Transport</h2>
-                <div class="panel__meta">@((Vm.Snapshot?.Transports.Count ?? 0).ToString())</div>
+                <h2>Machine & Transport</h2>
+                <button type="button" class="floatingCard__toggle" @onclick="(() => SideMinimized = !SideMinimized)">@(SideMinimized ? "+" : "-")</button>
             </div>
-            <div class="panel__body">
-                <TransportPanel Items="@(TransportPanelViewModel.Build(Vm.Snapshot))" />
-            </div>
-        </section>
 
-        <section class="panel panel--events">
-            <div class="panel__head">
-                <h2>Event Log</h2>
-                <div class="panel__meta">@((Vm.Snapshot?.RecentEvents.Count ?? 0).ToString())</div>
-            </div>
-            <div class="panel__body events">
-                <EventLogPanel Items="@(EventLogPanelViewModel.Build(Vm.Snapshot, take: 30))" />
-            </div>
-        </section>
+            @if (!SideMinimized)
+            {
+                <div class="dash__sideBody">
+                    <section class="panel panel--inner glass">
+                        <div class="panel__head">
+                            <h2>Machine</h2>
+                            <div class="panel__meta">@((Vm.Snapshot?.Machines.Count ?? 0).ToString())</div>
+                        </div>
+                        <div class="panel__body">
+                            <MachinePanel Items="@(MachinePanelViewModel.Build(Vm.Snapshot))" />
+                        </div>
+                    </section>
 
-        <section class="panel panel--legend">
-            <div class="panel__head">
-                <h2>Legend</h2>
-                <div class="panel__meta">Status</div>
-            </div>
+                    <section class="panel panel--inner glass">
+                        <div class="panel__head">
+                            <h2>Transport</h2>
+                            <div class="panel__meta">@((Vm.Snapshot?.Transports.Count ?? 0).ToString())</div>
+                        </div>
+                        <div class="panel__body">
+                            <TransportPanel Items="@(TransportPanelViewModel.Build(Vm.Snapshot))" />
+                        </div>
+                    </section>
+                </div>
+            }
+        </div>
+    </aside>
+
+    <section class="panel panel--events glass floatingCard @(LegendMinimized ? "floatingCard--min" : string.Empty)">
+        <div class="panel__head">
+            <h2>Legend</h2>
+            <button type="button" class="floatingCard__toggle" @onclick="(() => LegendMinimized = !LegendMinimized)">@(LegendMinimized ? "+" : "-")</button>
+        </div>
+        @if (!LegendMinimized)
+        {
             <div class="panel__body legend">
                 <div class="legend__item"><span class="dot dot--idle"></span> idle</div>
                 <div class="legend__item"><span class="dot dot--moving"></span> moving</div>
@@ -84,11 +120,39 @@
                 <div class="legend__sep"></div>
                 <div class="legend__item"><span class="dot dot--ready"></span> output ready</div>
             </div>
-        </section>
-    </main>
+        }
+    </section>
+
+    <section class="panel panel--log glass floatingCard @(LogMinimized ? "floatingCard--min" : string.Empty)">
+        <div class="panel__head">
+            <h2>Event Log</h2>
+            <button type="button" class="floatingCard__toggle" @onclick="(() => LogMinimized = !LogMinimized)">@(LogMinimized ? "+" : "-")</button>
+        </div>
+        @if (!LogMinimized)
+        {
+            <div class="panel__body events">
+                <EventLogPanel Items="@(EventLogPanelViewModel.Build(Vm.Snapshot, take: 30))" />
+            </div>
+        }
+    </section>
+
+    <ConfigEditorPanel Minimized="@ConfigMinimized" OnToggleMinimized="ToggleConfigMinimized" />
 </div>
 
 @code {
+    private const double MinZoom = 0.7d;
+    private const double MaxZoom = 2.2d;
+    private const double ZoomStep = 0.15d;
+
+    private double ZoomLevel { get; set; } = 1d;
+    private bool CanvasOnly { get; set; }
+    private bool HeroMinimized { get; set; }
+    private bool SummaryMinimized { get; set; }
+    private bool SideMinimized { get; set; }
+    private bool LegendMinimized { get; set; }
+    private bool LogMinimized { get; set; }
+    private bool ConfigMinimized { get; set; }
+
     protected override void OnInitialized()
     {
         Vm.Changed += OnChanged;
@@ -101,5 +165,18 @@
     }
 
     private void OnChanged() => InvokeAsync(StateHasChanged);
-}
 
+    private void ZoomIn() => ZoomLevel = Math.Min(MaxZoom, ZoomLevel + ZoomStep);
+
+    private void ZoomOut() => ZoomLevel = Math.Max(MinZoom, ZoomLevel - ZoomStep);
+
+    private void ResetZoom() => ZoomLevel = 1d;
+
+    private void ToggleCanvasOnly() => CanvasOnly = !CanvasOnly;
+
+    private Task ToggleConfigMinimized()
+    {
+        ConfigMinimized = !ConfigMinimized;
+        return Task.CompletedTask;
+    }
+}

--- a/src/EQFR.UI/Components/Pages/Dashboard.razor.css
+++ b/src/EQFR.UI/Components/Pages/Dashboard.razor.css
@@ -1,70 +1,236 @@
 .dash {
-  padding: 20px 18px 28px;
+  position: fixed;
+  inset: 0;
+  overflow: hidden;
+  background:
+    radial-gradient(1200px 700px at 18% 12%, rgba(29, 78, 216, 0.18), rgba(15, 23, 42, 0)),
+    radial-gradient(1000px 640px at 84% 82%, rgba(8, 145, 178, 0.14), rgba(15, 23, 42, 0)),
+    linear-gradient(180deg, #dbeafe 0%, #eff6ff 18%, #f8fafc 48%, #e2e8f0 100%);
 }
 
-.dash__header {
+.dash__canvas {
+  position: absolute;
+  inset: 0;
+  padding: 124px 470px 360px 260px;
+  transition: padding 220ms ease;
+}
+
+.dash--canvasOnly .dash__canvas {
+  padding: 24px;
+}
+
+.dash--canvasOnly .floatingCard {
+  display: none;
+}
+
+.dash__canvasToolbar {
+  position: absolute;
+  top: 74px;
+  right: 20px;
+  left: auto;
+  z-index: 120;
   display: flex;
-  gap: 16px;
-  align-items: flex-start;
-  justify-content: space-between;
-  margin-bottom: 16px;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  border-radius: 999px;
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.1);
 }
 
-.dash__title h1 {
+.dash__zoomButton,
+.dash__zoomReset,
+.floatingCard__toggle {
+  border: 0;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.84);
+  color: #0f172a;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 180ms ease, transform 180ms ease;
+}
+
+.dash__zoomButton {
+  width: 34px;
+  height: 34px;
+  font-size: 20px;
+  line-height: 1;
+}
+
+.dash__zoomReset {
+  min-height: 34px;
+  padding: 0 14px;
+  font-size: 12px;
+}
+
+.floatingCard__toggle {
+  width: 30px;
+  height: 30px;
+  font-size: 18px;
+  line-height: 1;
+}
+
+.dash__zoomButton:hover,
+.dash__zoomReset:hover,
+.floatingCard__toggle:hover {
+  background: rgba(255, 255, 255, 0.96);
+  transform: translateY(-1px);
+}
+
+.dash__zoomValue {
+  min-width: 54px;
+  text-align: center;
+  font-size: 12px;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.floatingCard__head,
+.panel__headActions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.floatingCard__title {
   margin: 0;
-  font-size: 26px;
-  letter-spacing: 0.2px;
+  font-size: 14px;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  color: #0f172a;
+}
+
+.floatingCard--min {
+  overflow: hidden;
+}
+
+.floatingCard--min .panel__body {
+  display: none;
+}
+
+.dash__hero {
+  position: absolute;
+  top: 72px;
+  left: 20px;
+  width: min(360px, calc(100vw - 40px));
+  padding: 16px 18px;
+}
+
+.dash__hero.floatingCard--min {
+  width: 220px;
+}
+
+.dash__eyebrow {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: #0f766e;
+}
+
+.dash__hero h1 {
+  margin: 0;
+  padding-top: 8px;
+  font-size: clamp(22px, 2vw, 32px);
+  line-height: 1.02;
+  letter-spacing: -0.04em;
+  color: #0f172a;
 }
 
 .dash__subtitle {
   margin-top: 6px;
-  color: #5b6674;
+  color: #475569;
   font-size: 13px;
 }
 
-.dash__controls {
+.dash__status {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
+  margin-top: 14px;
 }
 
-.btn {
-  appearance: none;
-  border: 1px solid #d2d8e1;
-  background: #f8fafc;
-  color: #26303b;
-  padding: 8px 12px;
-  border-radius: 10px;
-  font-weight: 600;
-  cursor: pointer;
-}
-
-.btn--disabled {
-  cursor: not-allowed;
-  opacity: 0.6;
-}
-
-.dash__grid {
+.dash__summary {
+  position: absolute;
+  top: 20px;
+  right: 20px;
   display: grid;
-  grid-template-columns: 2fr 1fr 1fr;
-  grid-template-rows: auto auto;
+  grid-template-columns: repeat(3, minmax(72px, 1fr));
+  gap: 10px;
+  width: min(330px, calc(100vw - 40px));
+  padding: 12px;
+}
+
+.dash__summary.floatingCard--min {
+  display: block;
+  width: 140px;
+}
+
+.dash__side {
+  position: absolute;
+  top: 124px;
+  right: 20px;
+  bottom: 216px;
+  width: min(380px, calc(100vw - 40px));
+}
+
+.dash__side.floatingCard--min {
+  top: 124px;
+  bottom: auto;
+  width: 160px;
+}
+
+.dash__sideBody {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) minmax(0, 1fr);
   gap: 14px;
+  padding: 14px;
+  height: calc(100% - 50px);
+}
+
+.panel--inner {
+  min-height: 0;
+}
+
+.panel--events {
+  position: absolute;
+  left: 20px;
+  bottom: 216px;
+  width: 180px;
+}
+
+.panel--events.floatingCard--min {
+  width: 120px;
+}
+
+.panel--log {
+  position: absolute;
+  left: 214px;
+  bottom: 216px;
+  width: min(440px, calc(100vw - 694px));
+  max-height: 180px;
+}
+
+.panel--log.floatingCard--min {
+  width: 140px;
 }
 
 .panel {
-  border: 1px solid #e3e8ef;
-  background: #ffffff;
+  border: 1px solid rgba(255, 255, 255, 0.45);
   border-radius: 14px;
   overflow: hidden;
-  box-shadow: 0 1px 0 rgba(16, 24, 40, 0.04);
+  box-shadow: 0 22px 50px rgba(15, 23, 42, 0.14);
+  min-height: 0;
 }
 
 .panel__head {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
   padding: 12px 14px;
-  border-bottom: 1px solid #eef2f6;
-  background: linear-gradient(180deg, #fbfdff, #ffffff);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(255, 255, 255, 0.3);
 }
 
 .panel__head h2 {
@@ -72,74 +238,43 @@
   font-size: 14px;
   letter-spacing: 0.4px;
   text-transform: uppercase;
+  color: #0f172a;
 }
 
 .panel__meta {
   font-size: 12px;
-  color: #7a8796;
+  color: #64748b;
 }
 
 .panel__body {
   padding: 14px;
+  height: calc(100% - 48px);
+  overflow: auto;
 }
 
-.panel--canvas {
-  grid-column: 1 / span 1;
-  grid-row: 1 / span 2;
-}
-
-.canvas {
-  min-height: 440px;
-  border-radius: 12px;
-  background:
-    radial-gradient(1200px 700px at 20% 10%, rgba(46, 107, 255, 0.08), rgba(255, 255, 255, 0)),
-    radial-gradient(900px 520px at 90% 40%, rgba(0, 184, 130, 0.08), rgba(255, 255, 255, 0)),
-    linear-gradient(180deg, #ffffff, #fbfcfe);
-  border: 1px dashed #dbe2ec;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: #516072;
-}
-
-.canvas__hint {
-  max-width: 360px;
-  text-align: center;
-  line-height: 1.45;
-  font-size: 14px;
-}
-
-.panel--events {
-  grid-column: 2 / span 1;
-}
-
-.panel--legend {
-  grid-column: 3 / span 1;
+.glass {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.72), rgba(255, 255, 255, 0.52));
+  backdrop-filter: blur(18px);
 }
 
 .kpi {
   display: grid;
   grid-template-columns: 1fr auto;
-  gap: 6px;
+  gap: 4px 8px;
   align-items: baseline;
-  margin-bottom: 10px;
 }
 
 .kpi__label {
-  color: #7a8796;
+  color: #64748b;
   font-size: 12px;
   text-transform: uppercase;
   letter-spacing: 0.4px;
 }
 
 .kpi__value {
-  font-size: 22px;
+  font-size: 24px;
   font-weight: 700;
-}
-
-.muted {
-  color: #6b7787;
-  font-size: 13px;
+  color: #0f172a;
 }
 
 .legend {
@@ -171,28 +306,93 @@
 
 .legend__sep {
   height: 1px;
-  background: #eef2f6;
+  background: rgba(148, 163, 184, 0.22);
   margin: 2px 0;
 }
 
-@media (max-width: 980px) {
-  .dash__header {
-    flex-direction: column;
-    align-items: stretch;
+.badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 0 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(255, 255, 255, 0.68);
+  color: #0f172a;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.badge--live {
+  color: #115e59;
+  background: rgba(204, 251, 241, 0.88);
+  border-color: rgba(13, 148, 136, 0.2);
+}
+
+@media (max-width: 1180px) {
+  .dash {
+    position: relative;
+    inset: auto;
+    min-height: 100vh;
+    overflow: auto;
+    padding: 16px;
   }
 
-  .dash__controls {
-    justify-content: flex-start;
+  .dash__canvas,
+  .dash__hero,
+  .dash__summary,
+  .dash__side,
+  .panel--events,
+  .panel--log,
+  .panel--config {
+    position: relative;
+    inset: auto;
+    top: auto;
+    right: auto;
+    bottom: auto;
+    left: auto;
+    width: auto;
+    max-height: none;
+    transform: none;
+    display: block;
   }
 
-  .dash__grid {
-    grid-template-columns: 1fr;
-    grid-template-rows: auto;
+  .dash__canvas {
+    padding: 0;
+    height: 58vh;
+    margin-bottom: 14px;
   }
 
-  .panel--canvas {
-    grid-column: 1;
-    grid-row: auto;
+  .dash__canvasToolbar {
+    top: 12px;
+    right: 12px;
+  }
+
+  .dash__sideBody {
+    height: auto;
+    padding: 14px;
+  }
+
+  .panel--events,
+  .panel--log,
+  .panel--config,
+  .dash__summary,
+  .dash__side,
+  .dash__hero {
+    margin-top: 14px;
   }
 }
 
+@media (max-width: 720px) {
+  .dash__summary {
+    grid-template-columns: 1fr;
+  }
+
+  .dash__canvasToolbar {
+    flex-wrap: wrap;
+    width: calc(100% - 24px);
+    justify-content: center;
+    right: 12px;
+    left: 12px;
+  }
+}

--- a/src/EQFR.UI/Components/Pages/LayoutBuilder.razor
+++ b/src/EQFR.UI/Components/Pages/LayoutBuilder.razor
@@ -1,0 +1,518 @@
+@page "/layout-builder"
+@rendermode InteractiveServer
+@using System.Globalization
+@using EQFR.UI.Services
+@inject FactoryConfigService ConfigService
+
+<PageTitle>Layout Builder</PageTitle>
+
+<div class="builder">
+    <section class="builder__preview glass">
+        <div class="builder__panelHead">
+            <div>
+                <div class="builder__eyebrow">UI Generator</div>
+                <h1>Layout Builder</h1>
+            </div>
+            <div class="builder__actions">
+                <button type="button" class="builder__button" @onclick="LoadAsync" disabled="@IsBusy">Reload</button>
+                <button type="button" class="builder__button" @onclick="ApplyFactoryFlowPreset">Apply Flow Preset</button>
+                <button type="button" class="builder__button builder__button--primary" @onclick="SaveAsync" disabled="@IsBusy">Save Layout + Routes</button>
+            </div>
+        </div>
+
+        <div class="builder__status">@StatusText</div>
+
+        <div class="builder__canvasWrap">
+            @if (Locations.Count == 0)
+            {
+                <div class="builder__empty">Belum ada node layout.</div>
+            }
+            else
+            {
+                <svg class="builder__canvas" viewBox="@BuildViewBox()" role="img" aria-label="Layout preview">
+                    @foreach (var edge in Routes)
+                    {
+                        var from = FindLocation(edge.From.LocationId);
+                        var to = FindLocation(edge.To.LocationId);
+                        if (from is null || to is null)
+                        {
+                            continue;
+                        }
+
+                        <line x1="@Svg(from.Position.X)" y1="@Svg(from.Position.Y)" x2="@Svg(to.Position.X)" y2="@Svg(to.Position.Y)" class="builder__edge" />
+                    }
+
+                    @foreach (var location in Locations)
+                    {
+                        <g transform="@Translate(location.Position.X, location.Position.Y)">
+                            <circle r="0.46" class="builder__node @NodeClass(location.Type)" />
+                            <text x="0.62" y="0.02" class="builder__label">@DisplayLabel(location)</text>
+                            <text x="0.62" y="0.36" class="builder__subLabel">@location.Id</text>
+                        </g>
+                    }
+                </svg>
+            }
+        </div>
+    </section>
+
+    <section class="builder__editor glass">
+        <div class="builder__columns">
+            <section class="builder__card">
+                <div class="builder__cardHead">
+                    <h2>Locations</h2>
+                    <button type="button" class="builder__button" @onclick="AddLocation">Add Location</button>
+                </div>
+
+                <div class="builder__list">
+                    @for (var i = 0; i < Locations.Count; i++)
+                    {
+                        var loc = Locations[i];
+                        <article class="builder__item">
+                            <div class="builder__itemHead">
+                                <strong>@DisplayLabel(loc)</strong>
+                                <button type="button" class="builder__iconButton" @onclick="(() => RemoveLocation(i))">x</button>
+                            </div>
+
+                            <div class="builder__grid">
+                                <label>
+                                    <span>Id</span>
+                                    <input @bind="loc.Id" @bind:event="oninput" />
+                                </label>
+                                <label>
+                                    <span>Display Name</span>
+                                    <input @bind="loc.DisplayName" @bind:event="oninput" />
+                                </label>
+                                <label>
+                                    <span>Type</span>
+                                    <select @bind="loc.Type">
+                                        <option value="Warehouse">Warehouse</option>
+                                        <option value="ChargingStation">ChargingStation</option>
+                                        <option value="Machine">Machine</option>
+                                        <option value="Other">Other</option>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>X</span>
+                                    <input type="number" step="0.1" @bind="loc.Position.X" @bind:event="oninput" />
+                                </label>
+                                <label>
+                                    <span>Y</span>
+                                    <input type="number" step="0.1" @bind="loc.Position.Y" @bind:event="oninput" />
+                                </label>
+                                <label>
+                                    <span>Ports</span>
+                                    <input value="@PortsSummary(loc)" @onchange="(e => UpdatePorts(loc, e.Value?.ToString()))" />
+                                </label>
+                            </div>
+                        </article>
+                    }
+                </div>
+            </section>
+
+            <section class="builder__card">
+                <div class="builder__cardHead">
+                    <h2>Routes</h2>
+                    <button type="button" class="builder__button" @onclick="AddRoute">Add Route</button>
+                </div>
+
+                <div class="builder__list">
+                    @for (var i = 0; i < Routes.Count; i++)
+                    {
+                        var route = Routes[i];
+                        <article class="builder__item">
+                            <div class="builder__itemHead">
+                                <strong>@route.From.LocationId -> @route.To.LocationId</strong>
+                                <button type="button" class="builder__iconButton" @onclick="(() => RemoveRoute(i))">x</button>
+                            </div>
+
+                            <div class="builder__grid">
+                                <label>
+                                    <span>From Location</span>
+                                    <select @bind="route.From.LocationId">
+                                        @foreach (var loc in Locations)
+                                        {
+                                            <option value="@loc.Id">@DisplayLabel(loc)</option>
+                                        }
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>From Port</span>
+                                    <input @bind="route.From.PortId" @bind:event="oninput" />
+                                </label>
+                                <label>
+                                    <span>To Location</span>
+                                    <select @bind="route.To.LocationId">
+                                        @foreach (var loc in Locations)
+                                        {
+                                            <option value="@loc.Id">@DisplayLabel(loc)</option>
+                                        }
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>To Port</span>
+                                    <input @bind="route.To.PortId" @bind:event="oninput" />
+                                </label>
+                                <label>
+                                    <span>Distance</span>
+                                    <input type="number" step="0.1" @bind="route.Distance" @bind:event="oninput" />
+                                </label>
+                                <label class="builder__checkbox">
+                                    <span>Bidirectional</span>
+                                    <input type="checkbox" @bind="route.IsBidirectional" />
+                                </label>
+                            </div>
+                        </article>
+                    }
+                </div>
+            </section>
+        </div>
+    </section>
+</div>
+
+@code {
+    private readonly List<LocationItem> Locations = [];
+    private readonly List<RouteItem> Routes = [];
+
+    private bool IsBusy { get; set; }
+    private string StatusText { get; set; } = "Loading...";
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        if (IsBusy) return;
+        IsBusy = true;
+        StatusText = "Loading layout...";
+        try
+        {
+            var layout = await ConfigService.GetSectionAsync<LayoutConfig>("layout") ?? new LayoutConfig();
+            var routes = await ConfigService.GetSectionAsync<RoutesConfig>("routes") ?? new RoutesConfig();
+
+            Locations.Clear();
+            Locations.AddRange((layout.Locations ?? []).Select(item => new LocationItem
+            {
+                Id = item.Id ?? string.Empty,
+                DisplayName = item.DisplayName ?? string.Empty,
+                Type = item.Type ?? "Other",
+                Position = new PositionItem { X = item.Position?.X ?? 0, Y = item.Position?.Y ?? 0 },
+                Ports = (item.Ports ?? []).Select(port => new PortItem { Id = port.Id ?? string.Empty, Type = port.Type ?? "Output" }).ToList()
+            }));
+
+            Routes.Clear();
+            Routes.AddRange((routes.Edges ?? []).Select(item => new RouteItem
+            {
+                From = new NodeRefItem { LocationId = item.From?.LocationId ?? string.Empty, PortId = item.From?.PortId ?? "IN" },
+                To = new NodeRefItem { LocationId = item.To?.LocationId ?? string.Empty, PortId = item.To?.PortId ?? "IN" },
+                IsBidirectional = item.IsBidirectional,
+                Distance = item.Distance ?? 1
+            }));
+
+            StatusText = "Loaded";
+        }
+        catch (Exception ex)
+        {
+            StatusText = $"Load failed: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private async Task SaveAsync()
+    {
+        if (IsBusy) return;
+        IsBusy = true;
+        StatusText = "Saving...";
+        try
+        {
+            var layout = new LayoutConfig
+            {
+                Locations = Locations.Select(item => new LayoutLocation
+                {
+                    Id = item.Id,
+                    DisplayName = string.IsNullOrWhiteSpace(item.DisplayName) ? item.Id : item.DisplayName,
+                    Type = item.Type,
+                    Position = new LayoutPosition { X = item.Position.X, Y = item.Position.Y },
+                    Ports = item.Ports.Select(port => new LayoutPort { Id = port.Id, Type = port.Type }).ToList()
+                }).ToList()
+            };
+
+            var routes = new RoutesConfig
+            {
+                Edges = Routes.Select(item => new RouteEdgeConfig
+                {
+                    From = new RouteNodeRef { LocationId = item.From.LocationId, PortId = item.From.PortId },
+                    To = new RouteNodeRef { LocationId = item.To.LocationId, PortId = item.To.PortId },
+                    IsBidirectional = item.IsBidirectional,
+                    Distance = item.Distance
+                }).ToList()
+            };
+
+            await ConfigService.SaveSectionAsync("layout", layout);
+            await ConfigService.SaveSectionAsync("routes", routes);
+            StatusText = "Saved layout and routes.";
+        }
+        catch (Exception ex)
+        {
+            StatusText = $"Save failed: {ex.Message}";
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private void ApplyFactoryFlowPreset()
+    {
+        Locations.Clear();
+        Locations.AddRange([
+            new LocationItem
+            {
+                Id = "WH_IN",
+                DisplayName = "Input Warehouse",
+                Type = "Warehouse",
+                Position = new PositionItem { X = 0, Y = 0 },
+                Ports = [new PortItem { Id = "OUT", Type = "Output" }]
+            },
+            new LocationItem
+            {
+                Id = "CS_1",
+                DisplayName = "Charging Station 1",
+                Type = "ChargingStation",
+                Position = new PositionItem { X = 2, Y = 1 },
+                Ports = [new PortItem { Id = "IN", Type = "Input" }, new PortItem { Id = "OUT", Type = "Output" }]
+            },
+            new LocationItem
+            {
+                Id = "ROLL_PRESS_1",
+                DisplayName = "Roll Press 1",
+                Type = "Machine",
+                Position = new PositionItem { X = 4, Y = 0 },
+                Ports = [new PortItem { Id = "IN", Type = "Input" }, new PortItem { Id = "OUT", Type = "Output" }]
+            },
+            new LocationItem
+            {
+                Id = "CS_2",
+                DisplayName = "Charging Station 2",
+                Type = "ChargingStation",
+                Position = new PositionItem { X = 6, Y = 1 },
+                Ports = [new PortItem { Id = "IN", Type = "Input" }, new PortItem { Id = "OUT", Type = "Output" }]
+            },
+            new LocationItem
+            {
+                Id = "WH_OUT",
+                DisplayName = "Output Warehouse",
+                Type = "Warehouse",
+                Position = new PositionItem { X = 8, Y = 0 },
+                Ports = [new PortItem { Id = "IN", Type = "Input" }]
+            }
+        ]);
+
+        Routes.Clear();
+        Routes.AddRange([
+            new RouteItem
+            {
+                From = new NodeRefItem { LocationId = "CS_1", PortId = "IN" },
+                To = new NodeRefItem { LocationId = "WH_IN", PortId = "OUT" },
+                IsBidirectional = true,
+                Distance = 2
+            },
+            new RouteItem
+            {
+                From = new NodeRefItem { LocationId = "CS_1", PortId = "IN" },
+                To = new NodeRefItem { LocationId = "ROLL_PRESS_1", PortId = "IN" },
+                IsBidirectional = true,
+                Distance = 2
+            },
+            new RouteItem
+            {
+                From = new NodeRefItem { LocationId = "ROLL_PRESS_1", PortId = "OUT" },
+                To = new NodeRefItem { LocationId = "CS_2", PortId = "IN" },
+                IsBidirectional = true,
+                Distance = 2
+            },
+            new RouteItem
+            {
+                From = new NodeRefItem { LocationId = "CS_2", PortId = "IN" },
+                To = new NodeRefItem { LocationId = "WH_OUT", PortId = "IN" },
+                IsBidirectional = true,
+                Distance = 2
+            }
+        ]);
+
+        StatusText = "Preset applied: CS_1 handles WH_IN <-> ROLL_PRESS_1 and CS_2 handles ROLL_PRESS_1 <-> WH_OUT.";
+    }
+
+    private void AddLocation()
+    {
+        var next = Locations.Count + 1;
+        Locations.Add(new LocationItem
+        {
+            Id = $"LOC_{next:00}",
+            DisplayName = $"Location {next}",
+            Type = "Other",
+            Position = new PositionItem { X = next, Y = 0 },
+            Ports = [new PortItem { Id = "IN", Type = "Input" }]
+        });
+    }
+
+    private void RemoveLocation(int index)
+    {
+        if (index < 0 || index >= Locations.Count) return;
+        var id = Locations[index].Id;
+        Locations.RemoveAt(index);
+        Routes.RemoveAll(route => string.Equals(route.From.LocationId, id, StringComparison.OrdinalIgnoreCase) || string.Equals(route.To.LocationId, id, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private void AddRoute()
+    {
+        var first = Locations.FirstOrDefault()?.Id ?? string.Empty;
+        var second = Locations.Skip(1).FirstOrDefault()?.Id ?? first;
+        Routes.Add(new RouteItem
+        {
+            From = new NodeRefItem { LocationId = first, PortId = "IN" },
+            To = new NodeRefItem { LocationId = second, PortId = "IN" },
+            IsBidirectional = true,
+            Distance = 1
+        });
+    }
+
+    private void RemoveRoute(int index)
+    {
+        if (index < 0 || index >= Routes.Count) return;
+        Routes.RemoveAt(index);
+    }
+
+    private LocationItem? FindLocation(string id) => Locations.FirstOrDefault(item => string.Equals(item.Id, id, StringComparison.OrdinalIgnoreCase));
+
+    private string DisplayLabel(LocationItem item) => string.IsNullOrWhiteSpace(item.DisplayName) ? item.Id : item.DisplayName;
+
+    private string PortsSummary(LocationItem item) => string.Join(", ", item.Ports.Select(port => $"{port.Id}:{port.Type}"));
+
+    private void UpdatePorts(LocationItem item, string? value)
+    {
+        item.Ports = string.IsNullOrWhiteSpace(value)
+            ? []
+            : value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(portText =>
+                {
+                    var parts = portText.Split(':', StringSplitOptions.TrimEntries);
+                    return new PortItem
+                    {
+                        Id = parts.ElementAtOrDefault(0) ?? "IN",
+                        Type = parts.ElementAtOrDefault(1) ?? "Input"
+                    };
+                })
+                .ToList();
+    }
+
+    private string BuildViewBox()
+    {
+        if (Locations.Count == 0)
+        {
+            return "0 0 10 6";
+        }
+
+        var minX = Locations.Min(item => item.Position.X) - 1.2;
+        var maxX = Locations.Max(item => item.Position.X) + 1.6;
+        var minY = Locations.Min(item => item.Position.Y) - 1.2;
+        var maxY = Locations.Max(item => item.Position.Y) + 1.2;
+        return string.Create(CultureInfo.InvariantCulture, $"{minX} {minY} {Math.Max(1, maxX - minX)} {Math.Max(1, maxY - minY)}");
+    }
+
+    private static string Svg(double value) => value.ToString(CultureInfo.InvariantCulture);
+
+    private static string Translate(double x, double y) => string.Create(CultureInfo.InvariantCulture, $"translate({x},{y})");
+
+    private static string NodeClass(string type) => type switch
+    {
+        "Warehouse" => "builder__node--wh",
+        "ChargingStation" => "builder__node--cs",
+        "Machine" => "builder__node--mc",
+        _ => "builder__node--other"
+    };
+
+    private sealed class LayoutConfig
+    {
+        public List<LayoutLocation> Locations { get; set; } = [];
+    }
+
+    private sealed class LayoutLocation
+    {
+        public string? Id { get; set; }
+        public string? DisplayName { get; set; }
+        public string? Type { get; set; }
+        public LayoutPosition? Position { get; set; }
+        public List<LayoutPort>? Ports { get; set; }
+    }
+
+    private sealed class LayoutPosition
+    {
+        public double X { get; set; }
+        public double Y { get; set; }
+    }
+
+    private sealed class LayoutPort
+    {
+        public string? Id { get; set; }
+        public string? Type { get; set; }
+    }
+
+    private sealed class RoutesConfig
+    {
+        public List<RouteEdgeConfig> Edges { get; set; } = [];
+    }
+
+    private sealed class RouteEdgeConfig
+    {
+        public RouteNodeRef? From { get; set; }
+        public RouteNodeRef? To { get; set; }
+        public bool IsBidirectional { get; set; }
+        public double? Distance { get; set; }
+    }
+
+    private sealed class RouteNodeRef
+    {
+        public string? LocationId { get; set; }
+        public string? PortId { get; set; }
+    }
+
+    private sealed class LocationItem
+    {
+        public string Id { get; set; } = string.Empty;
+        public string DisplayName { get; set; } = string.Empty;
+        public string Type { get; set; } = "Other";
+        public PositionItem Position { get; set; } = new();
+        public List<PortItem> Ports { get; set; } = [];
+    }
+
+    private sealed class PositionItem
+    {
+        public double X { get; set; }
+        public double Y { get; set; }
+    }
+
+    private sealed class PortItem
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Type { get; set; } = "Input";
+    }
+
+    private sealed class RouteItem
+    {
+        public NodeRefItem From { get; set; } = new();
+        public NodeRefItem To { get; set; } = new();
+        public bool IsBidirectional { get; set; }
+        public double Distance { get; set; } = 1;
+    }
+
+    private sealed class NodeRefItem
+    {
+        public string LocationId { get; set; } = string.Empty;
+        public string PortId { get; set; } = "IN";
+    }
+}

--- a/src/EQFR.UI/Components/Pages/LayoutBuilder.razor.css
+++ b/src/EQFR.UI/Components/Pages/LayoutBuilder.razor.css
@@ -1,0 +1,218 @@
+.builder {
+  min-height: 100vh;
+  padding: 84px 20px 20px;
+  display: grid;
+  grid-template-columns: minmax(360px, 46vw) minmax(420px, 1fr);
+  gap: 16px;
+  background:
+    radial-gradient(900px 540px at 12% 10%, rgba(14, 165, 233, 0.14), rgba(255, 255, 255, 0)),
+    radial-gradient(1000px 620px at 88% 82%, rgba(16, 185, 129, 0.12), rgba(255, 255, 255, 0)),
+    linear-gradient(180deg, #f8fafc 0%, #eff6ff 100%);
+}
+
+.builder__preview,
+.builder__editor {
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  border-radius: 24px;
+  padding: 18px;
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.12);
+  min-height: 0;
+}
+
+.builder__panelHead,
+.builder__cardHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.builder__eyebrow {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: #0f766e;
+}
+
+.builder h1,
+.builder h2 {
+  margin: 0;
+  color: #0f172a;
+}
+
+.builder h1 {
+  font-size: clamp(28px, 2.6vw, 40px);
+}
+
+.builder h2 {
+  font-size: 16px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.builder__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.builder__button,
+.builder__iconButton,
+.builder input,
+.builder select {
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.88);
+  color: #0f172a;
+}
+
+.builder__button,
+.builder__iconButton {
+  min-height: 38px;
+  padding: 0 14px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.builder__button--primary {
+  background: linear-gradient(135deg, #0f766e, #0284c7);
+  color: #f8fafc;
+  border-color: transparent;
+}
+
+.builder__iconButton {
+  width: 38px;
+  padding: 0;
+}
+
+.builder__status {
+  margin-top: 12px;
+  font-size: 13px;
+  color: #475569;
+}
+
+.builder__canvasWrap {
+  margin-top: 16px;
+  height: calc(100% - 84px);
+  min-height: 420px;
+  border-radius: 20px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.builder__canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  background:
+    linear-gradient(180deg, rgba(248, 250, 252, 0.9), rgba(226, 232, 240, 0.7));
+}
+
+.builder__empty {
+  height: 100%;
+  display: grid;
+  place-items: center;
+  color: #64748b;
+}
+
+.builder__edge {
+  stroke: rgba(59, 130, 246, 0.35);
+  stroke-width: 0.08;
+}
+
+.builder__node {
+  stroke: rgba(15, 23, 42, 0.18);
+  stroke-width: 0.06;
+}
+
+.builder__node--wh { fill: #e2e8f0; }
+.builder__node--cs { fill: #eef2ff; }
+.builder__node--mc { fill: #dcfce7; }
+.builder__node--other { fill: #f1f5f9; }
+
+.builder__label {
+  font-size: 0.34px;
+  font-weight: 700;
+  fill: rgba(15, 23, 42, 0.92);
+}
+
+.builder__subLabel {
+  font-size: 0.22px;
+  fill: rgba(71, 85, 105, 0.9);
+}
+
+.builder__columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  height: 100%;
+}
+
+.builder__card {
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
+.builder__list {
+  margin-top: 14px;
+  overflow: auto;
+  display: grid;
+  gap: 12px;
+  padding-right: 4px;
+}
+
+.builder__item {
+  padding: 14px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.62);
+  border: 1px solid rgba(226, 232, 240, 0.9);
+}
+
+.builder__itemHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.builder__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.builder label {
+  display: grid;
+  gap: 6px;
+  font-size: 12px;
+  color: #475569;
+}
+
+.builder input,
+.builder select {
+  min-height: 38px;
+  padding: 0 10px;
+}
+
+.builder__checkbox {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.builder__checkbox input {
+  min-height: auto;
+}
+
+@media (max-width: 1180px) {
+  .builder {
+    grid-template-columns: 1fr;
+  }
+
+  .builder__columns {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/EQFR.UI/Program.cs
+++ b/src/EQFR.UI/Program.cs
@@ -1,9 +1,31 @@
+using System.Net;
+using System.Net.Sockets;
 using EQFR.UI.Components;
 using EQFR.UI.Realtime;
 using EQFR.UI.Services;
 using EQFR.UI.ViewModels;
+using Microsoft.AspNetCore.Hosting;
 
 var builder = WebApplication.CreateBuilder(args);
+
+var configuredUrls = builder.Configuration[WebHostDefaults.ServerUrlsKey];
+if (!string.IsNullOrWhiteSpace(configuredUrls))
+{
+    var resolvedUrls = ResolveAvailableUrls(configuredUrls);
+    if (!string.Equals(configuredUrls, resolvedUrls, StringComparison.OrdinalIgnoreCase))
+    {
+        Console.WriteLine($"[EQFR.UI] Requested URL(s) '{configuredUrls}' in use. Falling back to '{resolvedUrls}'.");
+    }
+
+    builder.WebHost.UseUrls(resolvedUrls);
+}
+
+builder.Services.Configure<MockBackendOptions>(builder.Configuration.GetSection("MockBackend"));
+builder.Services.AddHttpClient("MockBackend", (serviceProvider, client) =>
+{
+    var options = serviceProvider.GetRequiredService<Microsoft.Extensions.Options.IOptions<MockBackendOptions>>().Value;
+    client.BaseAddress = new Uri(options.BaseUrl, UriKind.Absolute);
+});
 
 // Add services to the container.
 builder.Services.AddRazorComponents()
@@ -12,6 +34,7 @@ builder.Services.AddSignalR();
 builder.Services.AddSingleton<FactorySnapshotStore>();
 builder.Services.AddSingleton<SimulationControlService>();
 builder.Services.AddScoped<DashboardViewModel>();
+builder.Services.AddScoped<FactoryConfigService>();
 builder.Services.AddHostedService<SimulationBackgroundService>();
 
 var app = builder.Build();
@@ -20,7 +43,6 @@ var app = builder.Build();
 if (!app.Environment.IsDevelopment())
 {
     app.UseExceptionHandler("/Error", createScopeForErrors: true);
-    // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
     app.UseHsts();
 }
 app.UseStatusCodePagesWithReExecute("/not-found", createScopeForStatusCodePages: true);
@@ -34,3 +56,69 @@ app.MapRazorComponents<App>()
 app.MapHub<FactoryHub>("/realtime/factory");
 
 app.Run();
+
+static string ResolveAvailableUrls(string configuredUrls)
+{
+    var resolved = new List<string>();
+    var reservedPorts = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+    foreach (var rawUrl in configuredUrls.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+    {
+        if (!Uri.TryCreate(rawUrl, UriKind.Absolute, out var uri) || uri.Port <= 0 || !IsLocalHost(uri.Host))
+        {
+            resolved.Add(rawUrl);
+            continue;
+        }
+
+        var port = uri.Port;
+        while (!IsPortAvailable(uri.Host, port) || !reservedPorts.Add($"{uri.Host}:{port}"))
+        {
+            port++;
+        }
+
+        var uriBuilder = new UriBuilder(uri)
+        {
+            Port = port,
+            Path = string.Empty
+        };
+
+        resolved.Add(uriBuilder.Uri.ToString().TrimEnd('/'));
+    }
+
+    return string.Join(';', resolved);
+}
+
+static bool IsLocalHost(string host) =>
+    string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase) ||
+    string.Equals(host, "127.0.0.1", StringComparison.OrdinalIgnoreCase) ||
+    string.Equals(host, "::1", StringComparison.OrdinalIgnoreCase) ||
+    string.Equals(host, "[::1]", StringComparison.OrdinalIgnoreCase);
+
+static bool IsPortAvailable(string host, int port)
+{
+    if (string.Equals(host, "localhost", StringComparison.OrdinalIgnoreCase))
+    {
+        return CanBind(IPAddress.Loopback, port) && CanBind(IPAddress.IPv6Loopback, port);
+    }
+
+    if (string.Equals(host, "::1", StringComparison.OrdinalIgnoreCase) || string.Equals(host, "[::1]", StringComparison.OrdinalIgnoreCase))
+    {
+        return CanBind(IPAddress.IPv6Loopback, port);
+    }
+
+    return CanBind(IPAddress.Loopback, port);
+}
+
+static bool CanBind(IPAddress address, int port)
+{
+    try
+    {
+        using var listener = new TcpListener(address, port);
+        listener.Start();
+        return true;
+    }
+    catch (SocketException)
+    {
+        return false;
+    }
+}

--- a/src/EQFR.UI/Services/FactoryConfigService.cs
+++ b/src/EQFR.UI/Services/FactoryConfigService.cs
@@ -1,0 +1,75 @@
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+namespace EQFR.UI.Services;
+
+public sealed class FactoryConfigService(IHttpClientFactory httpClientFactory)
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+        PropertyNameCaseInsensitive = true
+    };
+
+    public async Task<FactoryConfigBundle> GetAsync(CancellationToken cancellationToken = default)
+    {
+        var client = httpClientFactory.CreateClient("MockBackend");
+        var payload = await client.GetFromJsonAsync<ConfigResponse>("/api/config", JsonOptions, cancellationToken)
+            ?? throw new InvalidOperationException("Config response was empty.");
+
+        return new FactoryConfigBundle(
+            payload.ConfigDir ?? string.Empty,
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["layout"] = ToPrettyJson(payload.Bundle?.Layout),
+                ["routes"] = ToPrettyJson(payload.Bundle?.Routes),
+                ["transport"] = ToPrettyJson(payload.Bundle?.Transport),
+                ["process"] = ToPrettyJson(payload.Bundle?.Process),
+                ["simulation"] = ToPrettyJson(payload.Bundle?.Simulation)
+            });
+    }
+
+    public async Task<T?> GetSectionAsync<T>(string section, CancellationToken cancellationToken = default)
+    {
+        var bundle = await GetAsync(cancellationToken);
+        if (!bundle.Sections.TryGetValue(section, out var json) || string.IsNullOrWhiteSpace(json))
+        {
+            return default;
+        }
+
+        return JsonSerializer.Deserialize<T>(json, JsonOptions);
+    }
+
+    public async Task SaveSectionAsync(string section, string json, CancellationToken cancellationToken = default)
+    {
+        using var document = JsonDocument.Parse(json);
+        var client = httpClientFactory.CreateClient("MockBackend");
+        using var content = new StringContent(document.RootElement.GetRawText(), Encoding.UTF8, "application/json");
+        using var response = await client.PostAsync($"/api/config/{section}", content, cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
+
+    public Task SaveSectionAsync<T>(string section, T payload, CancellationToken cancellationToken = default)
+    {
+        var json = JsonSerializer.Serialize(payload, JsonOptions);
+        return SaveSectionAsync(section, json, cancellationToken);
+    }
+
+    private static string ToPrettyJson(JsonElement? element)
+    {
+        if (element is null) return "{}";
+        return JsonSerializer.Serialize(element.Value, JsonOptions);
+    }
+
+    private sealed record ConfigResponse(string? ConfigDir, ConfigBundlePayload? Bundle);
+
+    private sealed record ConfigBundlePayload(
+        JsonElement Layout,
+        JsonElement Routes,
+        JsonElement Process,
+        JsonElement Simulation,
+        JsonElement Transport);
+}
+
+public sealed record FactoryConfigBundle(string ConfigDir, IReadOnlyDictionary<string, string> Sections);

--- a/src/EQFR.UI/Services/MockBackendOptions.cs
+++ b/src/EQFR.UI/Services/MockBackendOptions.cs
@@ -1,0 +1,7 @@
+namespace EQFR.UI.Services;
+
+public sealed class MockBackendOptions
+{
+    public string BaseUrl { get; set; } = "http://localhost:3001";
+    public int PollIntervalMs { get; set; } = 250;
+}

--- a/src/EQFR.UI/Services/SimulationBackgroundService.cs
+++ b/src/EQFR.UI/Services/SimulationBackgroundService.cs
@@ -1,13 +1,10 @@
-using EQFR.Biz.Dispatching;
-using EQFR.Biz.Machines;
-using EQFR.Biz.Routing;
-using EQFR.Biz.Runtime;
-using EQFR.Biz.Simulation;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using EQFR.Biz.Snapshots;
-using EQFR.Biz.Transport;
-using EQFR.IO.Config;
 using EQFR.UI.Realtime;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Options;
 
 namespace EQFR.UI.Services;
 
@@ -15,101 +12,69 @@ public sealed class SimulationBackgroundService(
     ILogger<SimulationBackgroundService> logger,
     IHubContext<FactoryHub> hubContext,
     FactorySnapshotStore snapshotStore,
-    SimulationControlService controls) : BackgroundService
+    IHttpClientFactory httpClientFactory,
+    IOptions<MockBackendOptions> options) : BackgroundService
 {
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        logger.LogInformation("EQFR simulation background service started.");
+        var settings = options.Value;
+        var client = httpClientFactory.CreateClient("MockBackend");
+        client.BaseAddress = new Uri(settings.BaseUrl, UriKind.Absolute);
 
-        var configDir = FindConfigDirectory(AppContext.BaseDirectory);
-        if (configDir is null)
-        {
-            logger.LogError("Config directory not found. Expected a 'config' folder in app directory or parent directories.");
-            return;
-        }
-
-        var loader = new JsonConfigLoader();
-        var bundleResult = loader.LoadFromDirectory(configDir);
-        if (!bundleResult.IsSuccess || bundleResult.Value is null)
-        {
-            logger.LogError("Failed to load config from '{ConfigDir}': {Error}", configDir, bundleResult.Error?.Message);
-            return;
-        }
-
-        var bundle = bundleResult.Value;
-        var (state, orchestrator, reservations) = BuildRuntime(bundle);
+        logger.LogInformation("EQFR UI backend polling service started. Backend: {BaseUrl}", client.BaseAddress);
 
         while (!stoppingToken.IsCancellationRequested)
         {
-            var now = DateTimeOffset.UtcNow;
-
-            if (controls.ConsumeResetRequested())
+            try
             {
-                (state, orchestrator, reservations) = BuildRuntime(bundle);
-            }
+                using var response = await client.GetAsync("/api/snapshot", stoppingToken);
+                if (response.StatusCode == System.Net.HttpStatusCode.NoContent)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(Math.Max(100, settings.PollIntervalMs)), stoppingToken);
+                    continue;
+                }
 
-            var desired = controls.DesiredStatus;
-            if (state.SimulationStatus != desired)
+                response.EnsureSuccessStatusCode();
+
+                var payload = await response.Content.ReadFromJsonAsync<SnapshotEnvelope>(JsonOptions, stoppingToken);
+                if (payload?.Snapshot is not null)
+                {
+                    snapshotStore.Update(payload.Snapshot);
+                    await hubContext.Clients.All.SendAsync("factorySnapshot", payload.Snapshot, cancellationToken: stoppingToken);
+
+                    var nextDelayMs = payload.Snapshot.TickOptions.TickInterval.TotalMilliseconds;
+                    var delay = TimeSpan.FromMilliseconds(Math.Max(100, nextDelayMs > 0 ? nextDelayMs : settings.PollIntervalMs));
+                    await Task.Delay(delay, stoppingToken);
+                    continue;
+                }
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
-                state = state with { SimulationStatus = desired };
+                break;
             }
-
-            if (state.SimulationStatus == EQFR.Common.SimulationStatus.Running)
+            catch (Exception ex)
             {
-                orchestrator.Tick(state, now);
+                logger.LogWarning(ex, "Failed to poll backend snapshot from {BaseUrl}", client.BaseAddress);
             }
-
-            var snapshot = SnapshotBuilder.Build(state, now);
-            snapshotStore.Update(snapshot);
-            await hubContext.Clients.All.SendAsync("factorySnapshot", snapshot, cancellationToken: stoppingToken);
 
             try
             {
-                var delay = state.SimulationStatus == EQFR.Common.SimulationStatus.Running
-                    ? state.TickOptions.TickInterval
-                    : TimeSpan.FromMilliseconds(Math.Max(250, state.TickOptions.TickInterval.TotalMilliseconds));
-
-                await Task.Delay(delay, stoppingToken);
+                await Task.Delay(TimeSpan.FromMilliseconds(Math.Max(250, settings.PollIntervalMs)), stoppingToken);
             }
             catch (OperationCanceledException)
             {
-                // ignore
+                break;
             }
         }
 
-        logger.LogInformation("EQFR simulation background service stopped.");
+        logger.LogInformation("EQFR UI backend polling service stopped.");
     }
 
-    private static string? FindConfigDirectory(string baseDirectory)
-    {
-        var dir = new DirectoryInfo(baseDirectory);
-
-        for (var i = 0; i < 8 && dir is not null; i++)
-        {
-            var candidate = Path.Combine(dir.FullName, "config");
-            if (Directory.Exists(candidate))
-            {
-                return candidate;
-            }
-
-            dir = dir.Parent;
-        }
-
-        return null;
-    }
-
-    private static (FactoryState State, SimulationOrchestrator Orchestrator, ReservationManager Reservations) BuildRuntime(ConfigBundle bundle)
-    {
-        var state = FactoryStateBuilder.BuildInitialState(bundle);
-
-        var reservations = new ReservationManager();
-        var transportEngine = new TransportEngine(reservations);
-        var machineEngine = new RollPressMachineEngine(bundle.Process);
-        var dispatcher = new Dispatcher();
-        var orchestrator = new SimulationOrchestrator(machineEngine, dispatcher, transportEngine);
-
-        state = state with { SimulationStatus = EQFR.Common.SimulationStatus.Stopped };
-        return (state, orchestrator, reservations);
-    }
+    private sealed record SnapshotEnvelope(DateTimeOffset? LastUpdatedUtc, FactorySnapshot? Snapshot);
 }
-

--- a/src/EQFR.UI/Services/SimulationControlService.cs
+++ b/src/EQFR.UI/Services/SimulationControlService.cs
@@ -5,7 +5,7 @@ namespace EQFR.UI.Services;
 public sealed class SimulationControlService
 {
     private readonly object _gate = new();
-    private SimulationStatus _desiredStatus = SimulationStatus.Stopped;
+    private SimulationStatus _desiredStatus = SimulationStatus.Running;
     private bool _resetRequested;
 
     public SimulationStatus DesiredStatus
@@ -62,4 +62,3 @@ public sealed class SimulationControlService
         }
     }
 }
-

--- a/src/EQFR.UI/ViewModels/DashboardViewModel.cs
+++ b/src/EQFR.UI/ViewModels/DashboardViewModel.cs
@@ -7,12 +7,10 @@ namespace EQFR.UI.ViewModels;
 public sealed class DashboardViewModel : IDisposable
 {
     private readonly FactorySnapshotStore _store;
-    private readonly SimulationControlService _controls;
 
-    public DashboardViewModel(FactorySnapshotStore store, SimulationControlService controls)
+    public DashboardViewModel(FactorySnapshotStore store)
     {
         _store = store;
-        _controls = controls;
         _store.Changed += OnStoreChanged;
 
         Snapshot = _store.Latest;
@@ -26,31 +24,6 @@ public sealed class DashboardViewModel : IDisposable
 
     public SimulationStatus SimulationStatus => Snapshot?.SimulationStatus ?? SimulationStatus.Stopped;
 
-    public bool CanStart => SimulationStatus != SimulationStatus.Running;
-    public bool CanPause => SimulationStatus == SimulationStatus.Running;
-    public bool CanReset => true;
-
-    public Task StartAsync()
-    {
-        _controls.Start();
-        Changed?.Invoke();
-        return Task.CompletedTask;
-    }
-
-    public Task PauseAsync()
-    {
-        _controls.Pause();
-        Changed?.Invoke();
-        return Task.CompletedTask;
-    }
-
-    public Task ResetAsync()
-    {
-        _controls.Reset();
-        Changed?.Invoke();
-        return Task.CompletedTask;
-    }
-
     public void Dispose()
     {
         _store.Changed -= OnStoreChanged;
@@ -62,4 +35,3 @@ public sealed class DashboardViewModel : IDisposable
         Changed?.Invoke();
     }
 }
-

--- a/src/EQFR.UI/ViewModels/FactoryCanvasViewModel.cs
+++ b/src/EQFR.UI/ViewModels/FactoryCanvasViewModel.cs
@@ -18,6 +18,7 @@ public static class FactoryCanvasViewModel
 
     public sealed record Node(
         string Id,
+        string DisplayName,
         string Type,
         double X,
         double Y
@@ -60,7 +61,7 @@ public static class FactoryCanvasViewModel
         var minY = snapshot.Locations.Min(l => l.Y);
         var maxY = snapshot.Locations.Max(l => l.Y);
 
-        var pad = 1.2; // world-units padding
+        var pad = 1.2;
         minX -= pad;
         maxX += pad;
         minY -= pad;
@@ -68,7 +69,7 @@ public static class FactoryCanvasViewModel
 
         var nodes = snapshot.Locations
             .OrderBy(l => l.Id, StringComparer.OrdinalIgnoreCase)
-            .Select(l => new Node(l.Id, l.Type, l.X, l.Y))
+            .Select(l => new Node(l.Id, string.IsNullOrWhiteSpace(l.DisplayName) ? l.Id : l.DisplayName, l.Type, l.X, l.Y))
             .ToList();
 
         var edges = snapshot.RouteEdges
@@ -111,7 +112,6 @@ public static class FactoryCanvasViewModel
                     return null;
                 }
 
-                // Stable small offset so multiple transports don't overlap perfectly.
                 var (dx, dy) = OffsetFor(t.Id);
                 return new TransportMarker(t.Id, t.Status, loc.X + dx, loc.Y + dy);
             })
@@ -135,11 +135,9 @@ public static class FactoryCanvasViewModel
                 hash = (hash * 31) + ch;
             }
 
-            // Range: [-0.18, 0.18]
             var dx = (((hash >> 0) & 0xFF) / 255.0 - 0.5) * 0.36;
             var dy = (((hash >> 8) & 0xFF) / 255.0 - 0.5) * 0.36;
             return (dx, dy);
         }
     }
 }
-

--- a/src/EQFR.UI/appsettings.Development.json
+++ b/src/EQFR.UI/appsettings.Development.json
@@ -4,5 +4,9 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "MockBackend": {
+    "BaseUrl": "http://localhost:3001",
+    "PollIntervalMs": 250
   }
 }

--- a/src/EQFR.UI/appsettings.json
+++ b/src/EQFR.UI/appsettings.json
@@ -5,5 +5,9 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "MockBackend": {
+    "BaseUrl": "http://localhost:3001",
+    "PollIntervalMs": 250
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
## Summary
- improve the dashboard canvas with zoom controls, canvas-only mode, and minimizable floating panels
- add a UI layout/config editor, plus a dedicated Layout Builder page for editing factory locations and routes
- update backend config/runtime flow so CS_1 handles WH_IN to ROLL_PRESS_1 and CS_2 handles ROLL_PRESS_1 to WH_OUT, with config save/reset support

## Notes
- backend runtime changes were syntax-checked with node --check
- local dotnet build on EQFR.UI can be blocked by a locked EQFR.UI.pdb when dotnet watch is running